### PR TITLE
Add AXL_XFER_BEST to autodetect the best transfer API

### DIFF
--- a/src/axl.h
+++ b/src/axl.h
@@ -22,6 +22,7 @@ typedef enum {
     AXL_XFER_ASYNC_DW,     /* Cray Datawarp */
     AXL_XFER_ASYNC_BBAPI,  /* IBM Burst Buffer API */
     AXL_XFER_ASYNC_CPPR,   /* Intel CPPR */
+    AXL_XFER_BEST,         /* Autodetect the best API from the node type */
 } axl_xfer_t;
 
 /* Read configuration from non-AXL-specific file


### PR DESCRIPTION
Add a new `AXL_XFER_BEST` type for `AXL_Create()`.  This allows the caller to leave it up to AXL to choose the best API for the particular node.  For example, if you're running on an IBM node, use the BB API. If you're running on a Cray, use DataWarp.  Otherwise use sync.  That way the caller doesn't have to have hardware-specific transfers in their checkpointing code.