### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/src/axl.h
+++ b/src/axl.h
@@ -8,10 +8,7 @@ extern "C" {
 
 #define AXL_SUCCESS (0)
 
-#define AXL_MAJOR "0"
-#define AXL_MINOR "0"
-#define AXL_PATCH "1"
-#define AXL_VERSION "0.0.1"
+#define AXL_VERSION "0.2.0"
 
 /* Supported AXL transfer methods
  * Note that DW, BBAPI, and CPPR must be found at compile time */


### PR DESCRIPTION
Tag version 0.2.0 to mark API change for addition of `AXL_XFER_BEST`. That way, we can point VeloC at the right version of AXL when we update it to use `AXL_XFER_BEST`.

Also, remove unused `AXL_MAJOR`, `AXL_MINOR`, and `AXL_PATCH`.