### PR TITLE
Add "default" and "native" transfer types

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -57,7 +57,6 @@ If a transfer fails, partially transferred files are not removed
 from the destination.
 
 ## Transfer types
-Currently, there are four transfer types:
 
 * AXL\_XFER\_SYNC - this is a synchronous transfer, which does not return until the files have been fully copied.  It uses POSIX I/O to directly read/write files.
 
@@ -66,3 +65,7 @@ Currently, there are four transfer types:
 * AXL\_XFER\_ASYNC\_BBAPI - this method uses [IBM's Burst Buffer API](https://github.com/IBM/CAST) to transfer files.  IBM's system software then takes over to move data in the background.  It's actually using NVMeoF, reading data from the local SSD from a remote node, so that the compute node is not really bothered once started.
 
 * AXL\_XFER\_ASYNC\_DW - this method uses [Cray's Datawarp API](https://www.cray.com/products/storage/datawarp).
+
+* AXL\_XFER\_DEFAULT - Let AXL choose the fastest transfer type that is compatible with all VeloC transfers.  This may or may not be the node's native transfer library.
+
+* AXL\_XFER\_NATIVE -  Use the node's native transfer library (like IBM Burst Buffer or Cray DataWarp) for transfers.  These native libraries may or may not support all VeloC transfers.

--- a/src/axl.h
+++ b/src/axl.h
@@ -13,13 +13,21 @@ extern "C" {
 /* Supported AXL transfer methods
  * Note that DW, BBAPI, and CPPR must be found at compile time */
 typedef enum {
-    AXL_XFER_NULL = 0,     /* placeholder to represent invalid value */
-    AXL_XFER_SYNC,         /* synchronous copy */
-    AXL_XFER_ASYNC_DAEMON, /* async daemon process */
-    AXL_XFER_ASYNC_DW,     /* Cray Datawarp */
-    AXL_XFER_ASYNC_BBAPI,  /* IBM Burst Buffer API */
-    AXL_XFER_ASYNC_CPPR,   /* Intel CPPR */
-    AXL_XFER_BEST,         /* Autodetect the best API from the node type */
+    AXL_XFER_NULL = 0,      /* placeholder to represent invalid value */
+    AXL_XFER_DEFAULT,       /* Autodetect and use the fastest API for this node
+                             * type that supports all AXL transfers.
+                             */
+    AXL_XFER_SYNC,          /* synchronous copy */
+    AXL_XFER_ASYNC_DAEMON,  /* async daemon process */
+    AXL_XFER_ASYNC_DW,      /* Cray Datawarp */
+    AXL_XFER_ASYNC_BBAPI,   /* IBM Burst Buffer API */
+    AXL_XFER_ASYNC_CPPR,    /* Intel CPPR */
+    AXL_XFER_NATIVE,        /* Autodetect and use the native API (BBAPI, DW,
+                             * etc) for this node type.  It may or may not
+                             * be compatible with all AXL transfers (like
+                             * shmem).  If there is no native API, fall back
+                             * to AXL_XFER_DEFAULT.
+                             */
 } axl_xfer_t;
 
 /* Read configuration from non-AXL-specific file


### PR DESCRIPTION
This adds in `AXL_XFER_DEFAULT` and `AXL_XFER_NATIVE`, and removes `AXL_XFER_BEST`:

AXL_XFER_DEFAULT:
Let AXL choose the fastest transfer type that is compatible with all VeloC transfers.  This may or may not be the node's native transfer library.

AXL_XFER_NATIVE:
Use the node's native transfer library (like IBM Burst Buffer or Cray DataWarp) for transfers.  These native libraries may or may not support all VeloC
transfers.