### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/src/axl.h
+++ b/src/axl.h
@@ -8,7 +8,7 @@ extern "C" {
 
 #define AXL_SUCCESS (0)
 
-#define AXL_VERSION "0.2.0"
+#define AXL_VERSION "0.3.0"
 
 /* Supported AXL transfer methods
  * Note that DW, BBAPI, and CPPR must be found at compile time */


### PR DESCRIPTION
Tag version 0.3.0 to mark API change for addition of AXL_XFER_DEFAULT and AXL_XFER_NAVIVE, and the removal of AXL_XFER_BEST.

After pulling in this commit, please create an `v0.3.0` tag.