### PR TITLE
Make each test case separate for 'make test', add BB API test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,9 +16,11 @@ TARGET_LINK_LIBRARIES(axl_cp axl)
 
 CONFIGURE_FILE(test_axl.sh ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
 
-# rountdrip tests
-ADD_TEST(transfer_tests test_axl.sh)
-
+ADD_TEST(sync_test test_axl.sh sync)
+ADD_TEST(pthreads_test test_axl.sh pthread)
+IF(BBAPI_FOUND)
+    ADD_TEST(bbapi_test test_axl.sh bbapi)
+ENDIF(BBAPI_FOUND)
 
 ####################
 # make a verbose "test" target named "check"

--- a/test/test_axl.sh
+++ b/test/test_axl.sh
@@ -4,6 +4,27 @@
 #
 # Make some files in /tmp and copy them using AXL.
 #
+#
+# Usage: test_axl [xfer_type]
+#
+#   xfer_type:    sync|pthread|bbapi|dw (defaults to sync if none specified)
+#
+
+xfer=$1
+if [ -z "$xfer" ] ; then
+    xfer=sync
+fi
+
+case $xfer in
+    sync) ;;
+    pthread) ;;
+    bbapi) ;;
+    dw) ;;
+    *)
+        echo "Invalid transfer type '$xfer'"
+        exit 1;
+        ;;
+esac
 
 src=$(mktemp -d)
 dest=$(mktemp -d)
@@ -68,11 +89,10 @@ function run_test
 create_files
 
 # Run our tests
-xfers="sync pthread"
-for i in $xfers ; do
-	if ! run_test $i ; then
+if ! run_test $xfer ; then
+        # our test failed
 		cleanup
 		exit 1
-	fi
-done
+fi
+
 cleanup


### PR DESCRIPTION
Break out each test case individually to follow the cmake test conventions.  Also, add the BB API tests if the BB API is compiled in. Test results now look like this:
```
$ make test
Running tests...
Test project /g/g0/hutter2/bbapi-newfixes/build
    Start 1: sync_test
1/3 Test #1: sync_test ........................   Passed    0.13 sec
    Start 2: pthreads_test
2/3 Test #2: pthreads_test ....................   Passed    0.12 sec
    Start 3: bbapi_test
3/3 Test #3: bbapi_test .......................   Passed   10.29 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) =  10.55 sec
```