### PR TITLE
Don't put axl_pthread_data pointer in KVTree

### DIFF
--- a/src/axl_internal.h
+++ b/src/axl_internal.h
@@ -26,8 +26,6 @@ extern kvtree* axl_file_lists;
 #define AXL_KEY_FILE_DEST     ("DEST")
 #define AXL_KEY_FILE_STATUS   ("STATUS")
 #define AXL_KEY_FILE_CRC      ("CRC")
-#define AXL_KEY_PTHREAD_DATA  ("PTHREAD_DATA")
-
 
 /* TRANSFER STATUS */
 #define AXL_STATUS_SOURCE (1)


### PR DESCRIPTION
This patch uses a linked list to lookup which `axl_pthread_data` is associated with each AXL ID.  Why put it in a linked list instead of just storing the pdata in the kvtree?  Because if we put it in a kvtree, and the app dies, the pdata pointer becomes stale, and would get erroneously freed as part of an `AXL_Stop()`.  Instead we use `axl_pthread_data_lookup()`, `axl_pthread_data_add()`, and `axl_pthread_data_remove()` to access the data.  This makes it so the pdata is ephemeral, only existing while the app is running.