### PR TITLE
Doxygen

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The Asynchronous Transfer Library provides a common C interface to transfer file
 between layers in an HPC storage hierarchy.
 
 For details on its usage, see [doc/README.md](doc/README.md).
+For API details, see [AXL User API docs](https://ecp-veloc.github.io/component-user-docs/).
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Asynchronous Transfer Library provides a common C interface to transfer file
 between layers in an HPC storage hierarchy.
 
 For details on its usage, see [doc/README.md](doc/README.md).
-For API details, see [AXL User API docs](https://ecp-veloc.github.io/component-user-docs/).
+For API details, see [AXL User API docs](https://ecp-veloc.github.io/component-user-docs/group__axl.html).
 
 ## Quickstart
 

--- a/src/axl.h
+++ b/src/axl.h
@@ -31,45 +31,45 @@ typedef enum {
     AXL_XFER_PTHREAD,      /* parallel copy using pthreads */
 } axl_xfer_t;
 
-/* Read configuration from non-AXL-specific file
+/** Read configuration from non-AXL-specific file
  * Also, start up vendor specific services */
 int AXL_Init (const char* state_file);
 
-/* Shutdown any vendor services */
+/** Shutdown any vendor services */
 int AXL_Finalize (void);
 
-/* Create a transfer handle (used for 0+ files)
+/** Create a transfer handle (used for 0+ files)
  * Type specifies a particular method to use
  * Name is a user/application provided string
  * Returns an ID to the transfer handle,
  * Returns -1 on error */
 int AXL_Create (axl_xfer_t type, const char* name);
 
-/* Add a file to an existing transfer handle */
+/** Add a file to an existing transfer handle */
 int AXL_Add (int id, const char* source, const char* destination);
 
-/* Initiate a transfer for all files in handle ID */
+/** Initiate a transfer for all files in handle ID */
 int AXL_Dispatch (int id);
 
-/* Non-blocking call to test if a transfer has completed,
+/** Non-blocking call to test if a transfer has completed,
  * returns AXL_SUCCESS if the transfer has completed,
  * does not indicate whether transfer was successful,
  * only whether it's done */
 int AXL_Test(int id);
 
-/* BLOCKING
+/** BLOCKING
  * Wait for a transfer to complete,
  * and finalize the transfer */
 int AXL_Wait (int id);
 
-/* Cancel an existing transfer, must call Wait
+/** Cancel an existing transfer, must call Wait
  * on cancelled transfers, if cancelled wait returns an error */
 int AXL_Cancel (int id);
 
-/* Perform cleanup of internal data associated with ID */
+/** Perform cleanup of internal data associated with ID */
 int AXL_Free (int id);
 
-/* Stop (cancel and free) all transfers,
+/** Stop (cancel and free) all transfers,
  * useful to clean the plate when restarting */
 int AXL_Stop (void);
 

--- a/src/axl.h
+++ b/src/axl.h
@@ -10,7 +10,21 @@ extern "C" {
 
 #define AXL_VERSION "0.3.0"
 
-/* Supported AXL transfer methods
+/** \defgroup axl AXL
+ *  \brief Asynchronous Transfer Library
+ *
+ * AXL is used to transfer a file from one path to another using
+ * synchronous and asynchronous methods. This can only be done between
+ * storage tiers, AXL does not (yet) support movement within a storage
+ * tier (such as between 2 compute nodes). Asynchronous methods
+ * include via pthreads, IBM BB API, Cray Datawarp. AXL will create
+ * directories for destination files. */
+
+/** \file axl.h
+ *  \ingroup axl
+ *  \brief asynchronous transfer library */
+
+/** Supported AXL transfer methods
  * Note that DW, BBAPI, and CPPR must be found at compile time */
 typedef enum {
     AXL_XFER_NULL = 0,      /* placeholder to represent invalid value */

--- a/src/axl_async_bbapi.h
+++ b/src/axl_async_bbapi.h
@@ -4,6 +4,12 @@
 #define AXL_BBAPI_KEY_TRANSFERHANDLE ("BB_TransferHandle")
 #define AXL_BBAPI_KEY_TRANSFERDEF ("BB_TransferDef")
 
+/** \file axl_async_bbapi.h
+ *  \ingroup axl
+ *  \brief implementation of axl for IBM bbapi */
+
+/** \name bbapi */
+///@{
 int axl_async_init_bbapi(void);
 int axl_async_finalize_bbapi(void);
 int axl_async_create_bbapi(int id);
@@ -12,5 +18,5 @@ int axl_async_start_bbapi(int id);
 int axl_async_test_bbapi(int id);
 int axl_async_wait_bbapi(int id);
 int axl_async_cancel_bbapi(int id);
-
+///@}
 #endif //AXL_ASYNC_BBAPI_H

--- a/src/axl_async_datawarp.h
+++ b/src/axl_async_datawarp.h
@@ -1,6 +1,12 @@
 #ifndef AXL_ASYNC_DATAWARP_H
 #define AXL_ASYNC_DATAWARP_H
 
+/** \file axl_async_datawarp.h
+ *  \ingroup axl
+ *  \brief implementation of axl for Cray datawarp */
+
+/** \name datawarp */
+///@{
 int axl_async_start_datawarp(int id);
 int axl_async_complete_datawarp(int id);
 int axl_async_stop_datawarp(int id);
@@ -8,5 +14,5 @@ int axl_async_test_datawarp(int id);
 int axl_async_wait_datawarp(int id);
 int axl_async_init_datawarp(void);
 int axl_async_finalize_datawarp(void);
-
+///@}
 #endif //AXL_ASYNC_DATAWARP_H

--- a/src/axl_pthread.h
+++ b/src/axl_pthread.h
@@ -1,10 +1,16 @@
 #ifndef AXL_PTHREAD_H
 #define AXL_PTHREAD_H
 
+/** \file axl_pthread.h
+ *  \ingroup axl
+ *  \brief implementation of axl using pthreads */
+
+/** \name pthread */
+///@{
 int axl_pthread_start(int id);
 int axl_pthread_test(int id);
 int axl_pthread_wait(int id);
 int axl_pthread_cancel(int id);
 void axl_pthread_free(int id);
-
+///@}
 #endif //AXL_PTHREAD_H

--- a/src/axl_sync.h
+++ b/src/axl_sync.h
@@ -1,8 +1,14 @@
 #ifndef AXL_SYNC_H
 #define AXL_SYNC_H
 
+/** \file axl_sync.h
+ *  \ingroup axl
+ *  \brief implementation of axl's synchronous mode */
+
+/** \name sync */
+///@{
 int axl_sync_start(int id);
 int axl_sync_test(int id);
 int axl_sync_wait(int id);
-
+///@}
 #endif //AXL_SYNC_H


### PR DESCRIPTION
Re-formatted the comments in the `.h` files to allow doxygen parsing for [generated documentation](https://ecp-veloc.github.io/component-user-docs/).