### PR TITLE
BBAPI fallback to sync if FS doesn't support extents

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -60,9 +60,9 @@ from the destination.
 
 * AXL\_XFER\_SYNC - this is a synchronous transfer, which does not return until the files have been fully copied.  It uses POSIX I/O to directly read/write files.
 
-* AXL\_XFER\_PTHREADS - Like AXL\_XFER\_SYNC, but use multiple threads to do the copy.
+* AXL\_XFER\_PTHREAD - Like AXL\_XFER\_SYNC, but use multiple threads to do the copy.
 
-* AXL\_XFER\_ASYNC\_BBAPI - this method uses [IBM's Burst Buffer API](https://github.com/IBM/CAST) to transfer files.  IBM's system software then takes over to move data in the background.  It's actually using NVMeoF, reading data from the local SSD from a remote node, so that the compute node is not really bothered once started.
+* AXL\_XFER\_ASYNC\_BBAPI - this method uses [IBM's Burst Buffer API](https://github.com/IBM/CAST) to transfer files.  IBM's system software then takes over to move data in the background.  It's actually using NVMeoF, reading data from the local SSD from a remote node, so that the compute node is not really bothered once started.  If either the source or destination filesystems don't support the BBAPI transfers, AXL will fall back to using a AXL\_XFER\_PTHREAD transfer instead.
 
 * AXL\_XFER\_ASYNC\_DW - this method uses [Cray's Datawarp API](https://www.cray.com/products/storage/datawarp).
 

--- a/src/axl_async_bbapi.c
+++ b/src/axl_async_bbapi.c
@@ -9,7 +9,14 @@
 #include <sys/syscall.h>
 #include "axl_internal.h"
 #include "axl_async_bbapi.h"
+#include "axl_pthread.h"
 
+/*
+ * This is the IBM Burst Buffer transfer implementation.  The BB API only
+ * supports transferring files between filesystems that support extents.  If
+ * the user tries to transfer to an unsupported filesystem, we fallback to
+ * a pthread transfer for the entire transfer.
+ */
 #ifdef HAVE_BBAPI
 #include <bbapi.h>
 
@@ -218,6 +225,15 @@ int axl_async_add_bbapi (int id, const char* source, const char* dest) {
  * Assumes that mkdirs have already happened */
 int axl_async_start_bbapi (int id) {
 #ifdef HAVE_BBAPI
+    if (axl_bbapi_in_fallback(id)) {
+        /*
+         * We're in fallback mode because some of the paths we want to
+         * transfer from/to are not compatible with the BBAPI transfers (like
+         * if the underlying filesystem doesn't support extent).
+         */
+        return axl_pthread_start(id);
+    }
+
     kvtree* file_list = kvtree_get_kv_int(axl_file_lists, AXL_KEY_HANDLE_UID, id);
 
     /* mark this transfer as in progress */
@@ -269,6 +285,10 @@ int axl_async_start_bbapi (int id) {
 
 int axl_async_test_bbapi (int id) {
 #ifdef HAVE_BBAPI
+    if (axl_bbapi_in_fallback(id)) {
+        return axl_pthread_test(id);
+    }
+
     kvtree* file_list = kvtree_get_kv_int(axl_file_lists, AXL_KEY_HANDLE_UID, id);
 
     /* Get the BB-Handle to query the status */
@@ -318,6 +338,10 @@ int axl_async_test_bbapi (int id) {
 
 int axl_async_wait_bbapi (int id) {
 #ifdef HAVE_BBAPI
+    if (axl_bbapi_in_fallback(id)) {
+        return axl_pthread_wait(id);
+    }
+
     kvtree* file_list = kvtree_get_kv_int(axl_file_lists, AXL_KEY_HANDLE_UID, id);
 
     /* Sleep until test changes set status */
@@ -329,7 +353,7 @@ int axl_async_wait_bbapi (int id) {
         /* if we're not done yet, sleep for some time and try again */
         kvtree_util_get_int(file_list, AXL_KEY_STATUS, &status);
         if (status == AXL_STATUS_INPROG) {
-            usleep(10*1000*1000);
+            usleep(100 * 1000);   /* 100ms */
         }
     }
 
@@ -345,6 +369,10 @@ int axl_async_wait_bbapi (int id) {
 
 int axl_async_cancel_bbapi (int id) {
 #ifdef HAVE_BBAPI
+    if (axl_bbapi_in_fallback(id)) {
+        return axl_pthread_cancel(id);
+    }
+
     kvtree* file_list = kvtree_get_kv_int(axl_file_lists, AXL_KEY_HANDLE_UID, id);
 
     /* Get the BB-Handle to query the status */
@@ -361,4 +389,50 @@ int axl_async_cancel_bbapi (int id) {
     return ret;
 #endif
     return AXL_FAILURE;
+}
+
+/*
+ * Return 1 if all paths for a given id's filelist in the kvtree are compatible
+ * with the BBAPI (all source and destination paths are on filesystems that
+ * support extents).  Return 0 if any of the source or destination paths do not
+ * support extents.
+ */
+int
+axl_all_paths_are_bbapi_compatible(int id)
+{
+#ifdef HAVE_BBAPI
+    char *src;
+    char *dst;
+    kvtree_elem *elem = NULL;
+
+    while ((elem = axl_get_next_path(id, elem, &src, &dst))) {
+        if (axl_file_supports_fiemap(src) == 0 ||
+            axl_file_supports_fiemap(dst) == 0) {
+                /* One of our paths doesn't support fiemap */
+            return (0);
+        }
+    }
+#endif
+    return (1);
+}
+
+/*
+ * If the BBAPI is in fallback mode return 1, else return 0.
+ *
+ * Fallback mode happens when we can't transfer the files using the BBAPI due
+ * to the source or destination nor supporting extents (which BBAPI requires).
+ * If we're in fallback mode, we use a more compatible transfer method.
+ */
+int
+axl_bbapi_in_fallback(int id)
+{
+    kvtree* file_list = kvtree_get_kv_int(axl_file_lists, AXL_KEY_HANDLE_UID, id);
+    int bbapi_fallback = 0;
+
+    if (kvtree_util_get_int(file_list, AXL_BBAPI_KEY_FALLBACK, &bbapi_fallback) !=
+        KVTREE_SUCCESS) {
+        /* Value isn't set, so we're not in fallback mode */
+        return 0;
+    }
+    return (bbapi_fallback);
 }

--- a/src/axl_async_bbapi.h
+++ b/src/axl_async_bbapi.h
@@ -3,6 +3,7 @@
 
 #define AXL_BBAPI_KEY_TRANSFERHANDLE ("BB_TransferHandle")
 #define AXL_BBAPI_KEY_TRANSFERDEF ("BB_TransferDef")
+#define AXL_BBAPI_KEY_FALLBACK ("BB_Fallback")
 
 /** \file axl_async_bbapi.h
  *  \ingroup axl
@@ -18,5 +19,17 @@ int axl_async_start_bbapi(int id);
 int axl_async_test_bbapi(int id);
 int axl_async_wait_bbapi(int id);
 int axl_async_cancel_bbapi(int id);
+
+int axl_all_paths_are_bbapi_compatible(int id);
+
+/*
+ * If the BBAPI is in fallback mode return 1, else return 0.
+ *
+ * Fallback mode happens when we can't transfer the files using the BBAPI due
+ * to lack of filesystem support.  Instead, fall back to a more compatible
+ * transfer mode.
+ */
+int axl_bbapi_in_fallback(int id);
+
 ///@}
 #endif //AXL_ASYNC_BBAPI_H

--- a/src/axl_internal.h
+++ b/src/axl_internal.h
@@ -61,6 +61,17 @@ Note: these functions are taken directly from SCR
 ========================================
 */
 
+#ifdef HAVE_BBAPI
+/*
+ * Returns 1 if the filesystem for a particular file supports the fiemap ioctl
+ * (the filesystem for the file is able to report extents).
+ * Returns 0 if extents are not supported.
+ *
+ * For example, tmpfs and ext4 support extents, NFS does not.
+ */
+int axl_file_supports_fiemap(char *path);
+#endif
+
 /* returns user's current mode as determine by their umask */
 mode_t axl_getmode(int read, int write, int execute);
 
@@ -108,5 +119,23 @@ extern size_t axl_file_buf_size;
 
 int axl_compare_files_or_dirs(char *path1, char *path2);
 void axl_free(void* p);
+
+
+/*
+ * This is an helper function to iterate though a file list for a given
+ * AXL ID.  Usage:
+ *
+ *    char *src;
+ *    char *dst;
+ *    char *kvtree_elem *elem = NULL;
+ *
+ *    while ((elem = axl_get_next_path(id, elem, &src, &dst))) {
+ *        printf("src %s, dst %s\n", src, dst);
+ *    }
+ *
+ *    src or dst can be set to NULL if you don't care about the value.
+ */
+kvtree_elem * axl_get_next_path(int id, kvtree_elem *elem, char **src,
+    char **dst);
 
 #endif /* AXL_INTERNAL_H */

--- a/src/axl_util.c
+++ b/src/axl_util.c
@@ -30,3 +30,53 @@ void axl_free(void* p) {
         *(void**)p = NULL;
     }
 }
+
+/*
+ * This is an helper function to iterate though a file list for a given
+ * AXL ID.  Usage:
+ *
+ *    char *src;
+ *    char *dst;
+ *    char *kvtree_elem *elem = NULL;
+ *
+ *    while ((elem = axl_get_next_path(id, elem, &src, &dst))) {
+ *        printf("src %s, dst %s\n", src, dst);
+ *    }
+ *
+ *    src or dst can be set to NULL if you don't care about the value.
+ */
+kvtree_elem *
+axl_get_next_path(int id, kvtree_elem *elem, char **src, char **dst)
+{
+    /* lookup transfer info for the given id */
+    kvtree* file_list;
+    kvtree* files;
+    kvtree* elem_hash;
+
+    file_list = kvtree_get_kv_int(axl_file_lists, AXL_KEY_HANDLE_UID, id);
+    if (!file_list) {
+        return NULL;
+    }
+
+    files = kvtree_get(file_list, AXL_KEY_FILES);
+
+    if (!elem) {
+        elem = kvtree_elem_first(files);
+    } else {
+        elem = kvtree_elem_next(elem);
+    }
+
+    /* get hash for this file */
+    elem_hash = kvtree_elem_hash(elem);
+
+    if (src) {
+        *src = kvtree_elem_key(elem);
+    }
+
+    if (dst) {
+        /* get destination for this file */
+        kvtree_util_get_str(elem_hash, AXL_KEY_FILE_DEST, dst);
+    }
+
+    return (elem);
+}


### PR DESCRIPTION
If the user requests a BBAPI transfer, and one or more of the source or destination paths in the file list aren't to a filesystem that BBAPI supports, then fallback to doing a pthreads transfer for all the files in the file list.  This gets around BBAPI giving you a "file not found" when it tries to transfer to/from a filesystem that doesn't support extents (like NFS).

Fixes:  #61