### PR TITLE
Patch for some OS X quirks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 langauge: c
 dist: trusty
 
-compiler:
-  - gcc
-  - clang
-
 matrix:
   include:
   - name: "GCC 4.9"

--- a/src/axl_io.c
+++ b/src/axl_io.c
@@ -185,7 +185,7 @@ int axl_open(const char* file, int flags, ...) {
     if (flags & O_CREAT) {
         va_list ap;
         va_start(ap, flags);
-        mode = va_arg(ap, mode_t);
+        mode = va_arg(ap, int);
         va_end(ap);
         mode_set = 1;
     }

--- a/src/axl_pthread.c
+++ b/src/axl_pthread.c
@@ -13,7 +13,7 @@
 #include <sys/sysinfo.h>
 #endif
 
-#define MIN(a,b) (a < b ? a : b)
+#define AXL_MIN(a,b) (a < b ? a : b)
 
 /*
  *  We default our number of threads to the lesser of:
@@ -335,7 +335,7 @@ int axl_pthread_start (int id)
     /* Get number of hardware threads */
     cpu_threads = axl_get_nprocs();
 
-    threads = MIN(cpu_threads, MIN(file_count, MAX_THREADS));
+    threads = AXL_MIN(cpu_threads, AXL_MIN(file_count, MAX_THREADS));
 
     /* Create the data structure for our threads */
     pdata = axl_pthread_create_thread_data(threads);


### PR DESCRIPTION
Mode type error from axl_io.c:188
> error: second argument to  'va_arg' is of promotable type 'mode_t' (aka 'unsigned short'); this va_arg has undefined behavior because arguments will be promoted to 'int' [-Werror,-Wvarargs]

Macro redefined error from axl_pthread.c:16
>  error: 'MIN' macro redefined [-Werror,-Wmacro-redefined]
