### PR TITLE
copy uid, gid, permissions, and timestamps

### DIFF
--- a/src/axl.c
+++ b/src/axl.c
@@ -59,6 +59,9 @@ static int axl_next_handle_UID = -1;
 /* tracks list of files written with transfer */
 kvtree* axl_file_lists = NULL;
 
+/* track whether file metadata should also be copied */
+int axl_copy_metadata = 0;
+
 /* given an id, lookup and return the file list and transfer type,
  * returns AXL_FAILURE if info could not be found */
 static int axl_get_info(int id, kvtree** list, axl_xfer_t* type, axl_xfer_state_t* state)
@@ -164,6 +167,13 @@ int AXL_Init (const char* state_file)
     char* val = getenv("AXL_DEBUG");
     if (val != NULL) {
         axl_debug = atoi(val);
+    }
+
+    /* initialize our flag on whether to copy file metadata */
+    axl_copy_metadata = 0;
+    val = getenv("AXL_COPY_METADATA");
+    if (val != NULL) {
+        axl_copy_metadata = atoi(val);
     }
 
     /* make a copy of the path to file to record our state */

--- a/src/axl_internal.h
+++ b/src/axl_internal.h
@@ -20,6 +20,10 @@ extern kvtree* axl_file_lists;
  * set in AXL_Init used in axl_dbg */
 extern int axl_debug;
 
+/* flag to track whether file metadata should also be copied,
+ * which includes uid/gid, permission bits, and timestamps */
+extern int axl_copy_metadata;
+
 /* "KEYS" */
 #define AXL_KEY_HANDLE_UID    ("ID")
 #define AXL_KEY_UNAME         ("NAME")
@@ -141,5 +145,12 @@ void axl_free(void* p);
  */
 kvtree_elem * axl_get_next_path(int id, kvtree_elem *elem, char **src,
     char **dst);
+
+/* given a source file, record its current uid/gid, permissions,
+ * and timestamps, record them in provided kvtree */
+int axl_meta_encode(const char* file, kvtree* meta);
+
+/* copy metadata settings recorded in provided kvtree to specified file */
+int axl_meta_apply(const char* file, const kvtree* meta);
 
 #endif /* AXL_INTERNAL_H */


### PR DESCRIPTION
If AXL_COPY_METADATA=1, then copy file metadata, including uid, gid, permissions, and timestamps.

This only applies to pthread and sync so far, with the assumption that IBM BB and Cray Datawarp may already be copying this metadata.  If not, it can be added to those.

Resolves: https://github.com/ECP-VeloC/AXL/issues/41