### PR TITLE
Mkdir

### DIFF
--- a/cmake/FindBBAPI.cmake
+++ b/cmake/FindBBAPI.cmake
@@ -1,8 +1,8 @@
 # - Try to find libbbAPI
 # Once done this will define
-#  BBAPI_FOUND - System has libdatawarp
-#  BBAPI_INCLUDE_DIRS - The libdatawarp include directories
-#  BBAPI_LIBRARIES - The libraries needed to use libdatawarp
+#  BBAPI_FOUND - System has libbbAPI
+#  BBAPI_INCLUDE_DIRS - The libbbAPI include directories
+#  BBAPI_LIBRARIES - The libraries needed to use libbbAPI
 
 FIND_PATH(WITH_BBAPI_PREFIX
     NAMES include/bbapi.h

--- a/src/axl_internal.h
+++ b/src/axl_internal.h
@@ -24,6 +24,10 @@ extern int axl_debug;
  * which includes uid/gid, permission bits, and timestamps */
 extern int axl_copy_metadata;
 
+/* whether axl should first create parent directories
+ * before transferring files */
+extern int axl_make_directories;
+
 /* "KEYS" */
 #define AXL_KEY_HANDLE_UID    ("ID")
 #define AXL_KEY_UNAME         ("NAME")


### PR DESCRIPTION
This fixes a typo in the comments of the FindBBAPI cmake code.

Defines new AXL_MKDIR configuration to let user disable directory creation in AXL. If AXL_MKDIR=0 then AXL will not create destination directories.  This saves unnecessary mkdir calls when the caller knows the directories already exist.