### PR TITLE
wait on cancelled transfer before free in stop

### DIFF
--- a/src/axl.c
+++ b/src/axl.c
@@ -845,18 +845,26 @@ int AXL_Stop ()
     int* ids;
     kvtree_list_int(ids_hash, &numids, &ids);
 
-    /* cancel and free each active id */
+    /* cancel each active id */
     int i;
     for (i = 0; i < numids; i++) {
-        /* get id for this transfer */
         int id = ids[i];
-
-        /* cancel it */
         if (AXL_Cancel(id) != AXL_SUCCESS) {
             rc = AXL_FAILURE;
         }
+    }
 
-        /* and free it */
+    /* wait */
+    for (i = 0; i < numids; i++) {
+        int id = ids[i];
+        if (AXL_Wait(id) != AXL_SUCCESS) {
+            rc = AXL_FAILURE;
+        }
+    }
+
+    /* and free it */
+    for (i = 0; i < numids; i++) {
+        int id = ids[i];
         if (AXL_Free(id) != AXL_SUCCESS) {
             rc = AXL_FAILURE;
         }


### PR DESCRIPTION
We say it's required to AXL_Wait on a transfer after it has been AXL_Cancel'ed.

https://github.com/ECP-VeloC/AXL/tree/master/doc

However we were not doing that within our AXL_Stop implementation.  I forget if that was intentional or an oversight.  This PR adds in the AXL_Wait call.

I also restructured the loop to issue all cancels, then all waits, then all frees.  If cancel or wait is slow, this lets a bunch of cancel/wait requests to run in parallel in case there are multiple outstanding transfers.