### PR TITLE
Use temporary file name when transferring

### DIFF
--- a/src/axl_async_bbapi.c
+++ b/src/axl_async_bbapi.c
@@ -7,6 +7,7 @@
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/syscall.h>
+#include <stdint.h>
 #include "axl_internal.h"
 #include "axl_async_bbapi.h"
 #include "axl_pthread.h"
@@ -283,6 +284,29 @@ int axl_async_create_bbapi(int id) {
     kvtree_util_set_ptr(file_list, AXL_BBAPI_KEY_TRANSFERDEF, tdef);
 
     return bb_check(rc);
+#endif
+    return AXL_FAILURE;
+}
+
+/*
+ * Return the BBTransferHandle_t (which is just a uint64_t) for a given AXL id.
+ *
+ * You can only call this function after axl_async_create_bbapi(id) has been
+ * called.
+ *
+ * Returns 0 on success, 1 on error.  On success, thandle contains the transfer
+ * handle value.
+ */
+int axl_async_get_bbapi_handle(int id, uint64_t *thandle)
+{
+#ifdef HAVE_BBAPI
+    kvtree* file_list = kvtree_get_kv_int(axl_file_lists, AXL_KEY_HANDLE_UID, id);
+
+    if (kvtree_util_get_unsigned_long(file_list, AXL_BBAPI_KEY_TRANSFERHANDLE,
+        thandle) != KVTREE_SUCCESS)
+            return 1;
+
+    return 0;
 #endif
     return AXL_FAILURE;
 }

--- a/src/axl_async_bbapi.h
+++ b/src/axl_async_bbapi.h
@@ -1,5 +1,6 @@
 #ifndef AXL_ASYNC_BBAPI_H
 #define AXL_ASYNC_BBAPI_H
+#include <stdint.h>
 
 #define AXL_BBAPI_KEY_TRANSFERHANDLE ("BB_TransferHandle")
 #define AXL_BBAPI_KEY_TRANSFERDEF ("BB_TransferDef")
@@ -15,6 +16,7 @@ int axl_async_init_bbapi(void);
 int axl_async_finalize_bbapi(void);
 int axl_async_create_bbapi(int id);
 int axl_async_add_bbapi(int id, const char* source, const char* destination);
+int axl_async_get_bbapi_handle(int id, uint64_t *thandle);
 int axl_async_start_bbapi(int id);
 int axl_async_test_bbapi(int id);
 int axl_async_wait_bbapi(int id);

--- a/src/axl_internal.h
+++ b/src/axl_internal.h
@@ -5,6 +5,8 @@
 #include "config.h"
 
 #include <zlib.h>
+#include <stdarg.h>
+
 #include "kvtree.h"
 #include "kvtree_util.h"
 
@@ -149,6 +151,9 @@ void axl_free(void* p);
  */
 kvtree_elem * axl_get_next_path(int id, kvtree_elem *elem, char **src,
     char **dst);
+
+/* Clone of apsrintf().  See the standard asprintf() man page for details */
+int asprintf(char** strp, const char* fmt, ...);
 
 /* given a source file, record its current uid/gid, permissions,
  * and timestamps, record them in provided kvtree */


### PR DESCRIPTION
This patch will add an temporary AXL extension to the file while it is copying.  The extension is removed after the file copy
is complete.  For example, if you're copying to `/tmp/file1`, AXL will actually copy to `/tmp/file1._AXL`, and then rename to
`/tmp/file1` at the end of the transfer. 

Additionally, a BB API transfer will also encode the transfer handle number into the extension like:

`/tmp/file1._AXL13456`

That way we can later recover the transfer handle number.

Fixes: #66