### PR TITLE
Add resumeable transfers, update state_file

### DIFF
--- a/src/axl_async_bbapi.h
+++ b/src/axl_async_bbapi.h
@@ -18,6 +18,7 @@ int axl_async_create_bbapi(int id);
 int axl_async_add_bbapi(int id, const char* source, const char* destination);
 int axl_async_get_bbapi_handle(int id, uint64_t *thandle);
 int axl_async_start_bbapi(int id);
+int axl_async_resume_bbapi(int id);
 int axl_async_test_bbapi(int id);
 int axl_async_wait_bbapi(int id);
 int axl_async_cancel_bbapi(int id);

--- a/src/axl_internal.h
+++ b/src/axl_internal.h
@@ -6,6 +6,7 @@
 
 #include <zlib.h>
 #include <stdarg.h>
+#include "axl.h"
 
 #include "kvtree.h"
 #include "kvtree_util.h"
@@ -13,10 +14,10 @@
 #define AXL_SUCCESS (0)
 #define AXL_FAILURE (-1)
 
-/* AXL internal data structure
- * this structure is accessed by the each transfer interface
- * any changes of the existing structure must be documented */
-extern kvtree* axl_file_lists;
+/*
+ * A list of pointers to kvtrees, indexed by AXL ID.
+ */
+kvtree** axl_kvtrees;
 
 /* current debug level for AXL library,
  * set in AXL_Init used in axl_dbg */
@@ -31,7 +32,6 @@ extern int axl_copy_metadata;
 extern int axl_make_directories;
 
 /* "KEYS" */
-#define AXL_KEY_HANDLE_UID    ("ID")
 #define AXL_KEY_UNAME         ("NAME")
 #define AXL_KEY_XFER_TYPE     ("TYPE")
 #define AXL_KEY_STATE         ("STATE")
@@ -40,6 +40,7 @@ extern int axl_make_directories;
 #define AXL_KEY_FILE_DEST     ("DEST")
 #define AXL_KEY_FILE_STATUS   ("STATUS")
 #define AXL_KEY_FILE_CRC      ("CRC")
+#define AXL_KEY_STATE_FILE    ("STATE_FILE")
 
 /* TRANSFER STATUS */
 #define AXL_STATUS_SOURCE (1)
@@ -112,7 +113,8 @@ ssize_t axl_write_attempt(const char* file, int fd, const void* buf, size_t size
 
 /* copy a file from src to dst and calculate CRC32 in the process
  * if crc == NULL, the CRC32 value is not computed */
-int axl_file_copy(const char* src_file, const char* dst_file, unsigned long buf_size, uLong* crc);
+int axl_file_copy(const char* src_file, const char* dst_file,
+    unsigned long buf_size, uLong* crc, int resume);
 
 /* opens, reads, and computes the crc32 value for the given filename */
 int axl_crc32(const char* filename, uLong* crc);

--- a/src/axl_pthread.h
+++ b/src/axl_pthread.h
@@ -8,6 +8,7 @@
 /** \name pthread */
 ///@{
 int axl_pthread_start(int id);
+int axl_pthread_resume(int id);
 int axl_pthread_test(int id);
 int axl_pthread_wait(int id);
 int axl_pthread_cancel(int id);

--- a/src/axl_sync.h
+++ b/src/axl_sync.h
@@ -10,5 +10,6 @@
 int axl_sync_start(int id);
 int axl_sync_test(int id);
 int axl_sync_wait(int id);
+int axl_sync_resume(int id);
 ///@}
 #endif //AXL_SYNC_H

--- a/src/axl_util.c
+++ b/src/axl_util.c
@@ -113,7 +113,7 @@ axl_get_next_path(int id, kvtree_elem *elem, char **src, char **dst)
     kvtree* files;
     kvtree* elem_hash;
 
-    file_list = kvtree_get_kv_int(axl_file_lists, AXL_KEY_HANDLE_UID, id);
+    file_list = axl_kvtrees[id];
     if (!file_list) {
         return NULL;
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,11 +23,25 @@ ADD_TEST(sync_test test_axl.sh sync)
 ADD_TEST(pthreads_test test_axl.sh pthread)
 IF(BBAPI_FOUND)
     ADD_TEST(bbapi_test test_axl.sh bbapi)
-    ADD_TEST(bbapi_cancel_test test_axl.sh -n 1500 -c 0.5 bbapi)
+
+    # Create 300 files, cancel transfer after 3 seconds.
+    ADD_TEST(bbapi_cancel_test test_axl.sh -n 300 -c 3 bbapi)
 ENDIF(BBAPI_FOUND)
 
-# Create 1500 files (~871MB) and cancel the test 200ms into the transfer
-ADD_TEST(pthreads_cancel_test test_axl.sh -n 1500 -c 0.2 pthread)
+# Create 100 files, pause the transfer after 1000 bytes or more
+# have been written, and cancel the transfer after 1 second.
+ADD_TEST(pthreads_cancel_test test_axl.sh -n 100 -p 1000 -c 1 pthread)
+
+# Create 100 files, pause the transfer after 1000 bytes or more
+# have been written, cancel the transfer after 1 second, and resume
+# the transfer.
+ADD_TEST(sync_resume_test test_axl.sh -n 100 -p 1000 -c 1 -U sync)
+ADD_TEST(pthread_resume_test test_axl.sh -n 100 -p 1000 -c 1 -U pthread)
+IF(BBAPI_FOUND)
+    # Create 300 files, cancel transfer after 3 seconds, resume transfer.
+    # Values found through experimentation.
+    ADD_TEST(bbapi_resume_test test_axl.sh -n 300 -c 3 -U  bbapi)
+ENDIF(BBAPI_FOUND)
 
 ####################
 # make a verbose "test" target named "check"


### PR DESCRIPTION
- Change the API so that `AXL_Create()` takes in a state_file argument, and remove state_file from `AXL_Init()`.  Use macro mangling for backwards compatibility so that this doesn't break applications that call the functions the old way.  We can get rid of the macro mangling once the FILO/VeloC are updated.

- Add `AXL_Resume(id)` to resume a transfer.  This works for sync, pthreads, and BBAPI.  For BBAPI, there's no way to resume  a transfer, so we just keep the existing transfer going.

- Update `axl_cp` and test cases with all these changes.