### PR TITLE
drop crc32 computation from axl_file_copy

### DIFF
--- a/src/axl_internal.h
+++ b/src/axl_internal.h
@@ -111,10 +111,9 @@ ssize_t axl_read_attempt(const char* file, int fd, void* buf, size_t size);
 /* make a good attempt to write to file (retries, if necessary, return error if fail) */
 ssize_t axl_write_attempt(const char* file, int fd, const void* buf, size_t size);
 
-/* copy a file from src to dst and calculate CRC32 in the process
- * if crc == NULL, the CRC32 value is not computed */
+/* copy a file from src to dst */
 int axl_file_copy(const char* src_file, const char* dst_file,
-    unsigned long buf_size, uLong* crc, int resume);
+    unsigned long buf_size, int resume);
 
 /* opens, reads, and computes the crc32 value for the given filename */
 int axl_crc32(const char* filename, uLong* crc);

--- a/src/axl_io.c
+++ b/src/axl_io.c
@@ -518,7 +518,7 @@ static unsigned long axl_debug_pause_after(void)
 /* TODO: could apply compression/decompression here */
 /* copy src_file (full path) to dest_path and return new full path in dest_file */
 int axl_file_copy(const char* src_file, const char* dst_file,
-    unsigned long buf_size, uLong* crc, int resume) {
+    unsigned long buf_size, int resume) {
     off_t start_offset;
     int flags;
     unsigned long total_copied = 0;
@@ -586,11 +586,6 @@ int axl_file_copy(const char* src_file, const char* dst_file,
         return AXL_FAILURE;
     }
 
-    /* initialize crc values */
-    if (crc != NULL) {
-        *crc = crc32(0L, Z_NULL, 0);
-    }
-
     /* Resume the transfer to our destination file where we left off */
     if (resume) {
         /* Seek to the end of our destination file, while recording offset */
@@ -615,11 +610,6 @@ int axl_file_copy(const char* src_file, const char* dst_file,
 
         /* if we read some bytes, write them out */
         if (nread > 0) {
-            /* optionally compute crc value as we go */
-            if (crc != NULL) {
-                *crc = crc32(*crc, (const Bytef*) buf, (uInt) nread);
-            }
-
             /* write our nread bytes out */
             int nwrite = axl_write_attempt(dst_file, dst_fd, buf, nread);
 

--- a/src/axl_pthread.c
+++ b/src/axl_pthread.c
@@ -207,7 +207,7 @@ axl_pthread_func(void *arg)
         src = kvtree_elem_key(elem);
         kvtree_util_get_str(elem_hash, AXL_KEY_FILE_DEST, &dst);
 
-        rc = axl_file_copy(src, dst, axl_file_buf_size, NULL, pdata->resume);
+        rc = axl_file_copy(src, dst, axl_file_buf_size, pdata->resume);
         AXL_DBG(2, "%s: Read and copied %s to %s, rc %d",
             __func__, src, dst, rc);
 

--- a/src/axl_sync.c
+++ b/src/axl_sync.c
@@ -34,7 +34,7 @@ int __axl_sync_start (int id, int resume)
         /* Copy the file */
         char* destination;
         kvtree_util_get_str(elem_hash, AXL_KEY_FILE_DEST, &destination);
-        int tmp_rc = axl_file_copy(source, destination, axl_file_buf_size, NULL, resume);
+        int tmp_rc = axl_file_copy(source, destination, axl_file_buf_size, resume);
         if (tmp_rc == AXL_SUCCESS) {
             kvtree_util_set_int(elem_hash, AXL_KEY_FILE_STATUS, AXL_STATUS_DEST);
         } else {


### PR DESCRIPTION
We weren't actively using the feature in axl_file_copy that computes the crc32 value while copying the file, but the addition of resume broke it.  Since we're not using the crc feature, this removes it.  It can be added back later if needed.