### PR TITLE
Style

### DIFF
--- a/src/axl.c
+++ b/src/axl.c
@@ -918,11 +918,6 @@ int AXL_Test (int id)
     }
 
 end:
-
-    if (rc == AXL_SUCCESS) {
-        axl_rename_files_to_final_names(id);
-    }
-
     return rc;
 }
 

--- a/src/axl.h
+++ b/src/axl.h
@@ -80,7 +80,7 @@ int AXL_Finalize (void);
  */
 #define AXL_Create(type, name, ...) \
         __AXL_Create(type, name, GET_ARG0(__VA_ARGS__))
-int __AXL_Create(axl_xfer_t xtype, const char* name, const char* state_file);
+int __AXL_Create (axl_xfer_t xtype, const char* name, const char* state_file);
 
 /** Add a file to an existing transfer handle */
 int AXL_Add (int id, const char* source, const char* destination);
@@ -103,7 +103,7 @@ int AXL_Resume (int id);
  * returns AXL_SUCCESS if the transfer has completed,
  * does not indicate whether transfer was successful,
  * only whether it's done */
-int AXL_Test(int id);
+int AXL_Test (int id);
 
 /** BLOCKING
  * Wait for a transfer to complete,

--- a/src/axl_async_bbapi.h
+++ b/src/axl_async_bbapi.h
@@ -16,7 +16,7 @@ int axl_async_init_bbapi(void);
 int axl_async_finalize_bbapi(void);
 int axl_async_create_bbapi(int id);
 int axl_async_add_bbapi(int id, const char* source, const char* destination);
-int axl_async_get_bbapi_handle(int id, uint64_t *thandle);
+int axl_async_get_bbapi_handle(int id, uint64_t* thandle);
 int axl_async_start_bbapi(int id);
 int axl_async_resume_bbapi(int id);
 int axl_async_test_bbapi(int id);

--- a/src/axl_async_datawarp.c
+++ b/src/axl_async_datawarp.c
@@ -8,213 +8,229 @@
 #include "datawarp.h"
 #endif
 
-int axl_async_start_datawarp(int id){
+int axl_async_start_datawarp(int id)
+{
 #ifdef HAVE_DATAWARP
-  /* For each file figure out where it goes */
-  kvtree_elem* elem;
-
-  /* Record that we started transfer of this file list */
-  kvtree* file_list = kvtree_get_kv_int(axl_async_file_lists, AXL_KEY_HANDLE_UID, id);
-  kvtree_util_set_int(file_list, AXL_KEY_STATUS, AXL_STATUS_INPROG);
-
-  /* iterate over files */
-  kvtree* files = kvtree_get(file_list, AXL_KEY_FILE);
-  for (elem = kvtree_elem_first(files);
-       elem != NULL;
-       elem = kvtree_elem_next(elem))
-  {
-    /* get the filename */
-    char* file = kvtree_elem_key(elem);
-
-    /* get the hash for this file */
-    kvtree* elem_hash = kvtree_elem_hash(elem);
-
-    /* get the destination for this file */
-    char* dest_file;
-    kvtree_util_get_str(elem_hash, AXL_KEY_FILE_DEST, &dest_file);
-
-    /* Stage out file */
-    int stage_out = dw_stage_file_out(file, dest_file, DW_STAGE_IMMEDIATE);
-    if(stage_out != 0){
-      axl_abort(-1, "Datawarp stage file out failed with error %d @ %s:%d",
+    /* Record that we started transfer of this file list */
+    kvtree* file_list = kvtree_get_kv_int(axl_async_file_lists, AXL_KEY_HANDLE_UID, id);
+    kvtree_util_set_int(file_list, AXL_KEY_STATUS, AXL_STATUS_INPROG);
+ 
+    /* iterate over files */
+    kvtree_elem* elem;
+    kvtree* files = kvtree_get(file_list, AXL_KEY_FILE);
+    for (elem = kvtree_elem_first(files);
+         elem != NULL;
+         elem = kvtree_elem_next(elem))
+    {
+        /* get the filename */
+        char* file = kvtree_elem_key(elem);
+ 
+        /* get the hash for this file */
+        kvtree* elem_hash = kvtree_elem_hash(elem);
+ 
+        /* get the destination for this file */
+        char* dest_file;
+        kvtree_util_get_str(elem_hash, AXL_KEY_FILE_DEST, &dest_file);
+ 
+        /* Stage out file */
+        int stage_out = dw_stage_file_out(file, dest_file, DW_STAGE_IMMEDIATE);
+        if (stage_out != 0) {
+            axl_abort(-1,
+                "Datawarp stage file out failed with error %d @ %s:%d",
                 -stage_out, __FILE__, __LINE__
-        );
-    }
-
-    /* record that the file is in progress */
-    kvtree_util_set_int(elem_hash, AXL_KEY_FILE_STATUS, AXL_STATUS_INPROG);
-  }
-  return AXL_SUCCESS;
-#endif
-  return AXL_FAILURE;
-}
-
-
-int axl_async_complete_datawarp(int id){
-  /* no datawarp specific code for async complete */
-  return AXL_SUCCESS;
-}
-
-
-int axl_async_stop_datawarp(int id){
-#ifdef HAVE_DATAWARP
-  kvtree_elem* elem;
-
-  /* iterate over files */
-  kvtree* file_list = kvtree_get_kv_int(axl_async_file_lists, AXL_KEY_HANDLE_UID, id);
-  kvtree* files = kvtree_get(file_list, AXL_KEY_FILE);
-  for (elem = kvtree_elem_first(files);
-       elem != NULL;
-       elem = kvtree_elem_next(elem))
-  {
-    char* file = kvtree_elem_key(elem);
-    dw_terminate_file_stage(file);
-
-    kvtree* elem_hash = kvtree_elem_hash(elem);
-    kvtree_util_set_int(elem_hash, AXL_KEY_FILE_STATUS, AXL_STATUS_SOURCE);
-  }
-
-  /* mark full file list as not transfered */
-  kvtree_util_set_int(file_list, AXL_KEY_STATUS, AXL_STATUS_SOURCE);
-  return AXL_SUCCESS;
-#endif
-  return AXL_FAILURE;
-}
-
-
-int axl_async_test_datawarp(int id){
-#ifdef HAVE_DATAWARP
-  /* assume transfer is complete */
-  int transfer_complete = 1;
-
-  kvtree_elem* elem;
-  int complete = 0;
-  int pending = 0;
-  int deferred = 0;
-  int failed = 0;
-  int test_complete;
-  int test_pending;
-  int test_deferred;
-  int test_failed;
-
-  /* iterate over files */
-  kvtree* file_list = kvtree_get_kv_int(axl_async_file_lists, AXL_KEY_HANDLE_UID, id);
-  kvtree* files = kvtree_get(file_list, AXL_KEY_FILE);
-  for (elem = kvtree_elem_first(files);
-       elem != NULL;
-       elem = kvtree_elem_next(elem))
-  {
-    kvtree* elem_hash = kvtree_elem_hash(elem);
-    int status;
-    kvtree_util_get_int(elem_hash, AXL_KEY_FILE_STATUS, &status);
-
-    switch(status){
-    case AXL_STATUS_DEST:
-      break;
-    case AXL_STATUS_INPROG:
-      char* file = kvtree_elem_key(elem);
-      int test = dw_query_file_stage(file, &test_complete, &test_pending, &test_deferred,
-                                     &test_failed);
-      if(test == 0){
-        complete += test_complete;
-        pending += test_pending;
-        deferred += test_deferred;
-        failed += test_failed;
-
-        int file_status = AXL_STATUS_INPROG;
-        if(test_failed){
-          file_status = AXL_STATUS_ERROR;
-        }else if(test_complete){
-          file_status = AXL_STATUS_DEST;
+            );
         }
-        kvtree_util_set_int(elem_hash, AXL_KEY_FILE_STATUS, file_status);
-      }else{
-        axl_abort(-1, "Datawarp failed with error %d @ %s:%d",
-                  -test, __FILE__, __LINE__
-          );
-      }
-      break;
-    case AXL_STATUS_ERROR:
-    case AXL_STATUS_SOURCE:
-    default:
-      axl_abort(-1, "Wait called on file with invalid status @ %s:%d",
-                __FILE__, __LINE__
-        );
+ 
+        /* record that the file is in progress */
+        kvtree_util_set_int(elem_hash, AXL_KEY_FILE_STATUS, AXL_STATUS_INPROG);
     }
-  }
-
-  int status = AXL_STATUS_DEST;
-  if(failed != 0){
-    status = AXL_STATUS_ERROR;
-  }else if(pending != 0 || deferred != 0){
-    transfer_complete = 0;
-    status = AXL_STATUS_INPROG
-  }
-
-  /* record the transfer status */
-  kvtree_util_set_int(file_list, AXL_KEY_STATUS, status);
-
-  if(transfer_complete){
-    return AXL_SUCCESS
-  }
+ 
+    return AXL_SUCCESS;
 #endif
-  return AXL_FAILURE;
+
+    return AXL_FAILURE;
 }
 
+int axl_async_complete_datawarp(int id)
+{
+    /* no datawarp specific code for async complete */
+    return AXL_SUCCESS;
+}
 
-int axl_async_wait_datawarp(int id){
+int axl_async_stop_datawarp(int id)
+{
 #ifdef HAVE_DATAWARP
-  /* Get the list of files */
-  kvtree_elem* elem = NULL;
-  int dw_wait = 0;
+    kvtree* file_list = kvtree_get_kv_int(axl_async_file_lists, AXL_KEY_HANDLE_UID, id);
+    kvtree* files     = kvtree_get(file_list, AXL_KEY_FILE);
 
-  /* iterate over files */
-  kvtree* file_list = kvtree_get_kv_int(axl_async_file_lists, AXL_KEY_HANDLE_UID, id);
-  kvtree* files = kvtree_get(file_list, AXL_KEY_FILE);
-  for (elem = kvtree_elem_first(files);
-       elem != NULL;
-       elem = kvtree_elem_next(elem))
-  {
-    kvtree* elem_hash = kvtree_elem_hash(elem);
-    int status;
-    kvtree_util_get_int(elem_hash, AXL_KEY_FILE_STATUS, &status);
+    /* iterate over files */
+    kvtree_elem* elem;
+    for (elem = kvtree_elem_first(files);
+         elem != NULL;
+         elem = kvtree_elem_next(elem))
+    {
+        char* file = kvtree_elem_key(elem);
 
-    switch(status){
-    case AXL_STATUS_DEST:
-      break;
-    case AXL_STATUS_INPROG:
-      /* Do the wait on each file */
-      char* file = kvtree_elem_key(elem);
-      dw_wait = dw_wait_file_stage(file);
-      if (dw_wait != 0){
-        axl_abort(-1, "Datawarp wait operation failed with error %d @ %s:%d",
-                  -dw_wait, __FILE__, __LINE__
-          );
-      }
-      kvtree_util_set_int(elem_hash, AXL_KEY_FILE_STATUS, AXL_STATUS_DEST);
-      break;
-    case AXL_STATUS_SOURCE:
-    case AXL_STATUS_ERROR:
-    default:
-      axl_abort(-1, "Wait operation called on file with invalid status @ %s:%d",
-                __FILE__, __LINE__
-        );
+        dw_terminate_file_stage(file);
+
+        kvtree* elem_hash = kvtree_elem_hash(elem);
+        kvtree_util_set_int(elem_hash, AXL_KEY_FILE_STATUS, AXL_STATUS_SOURCE);
     }
-  }
 
-  /* record transfer complete */
-  kvtree_util_set_int(file_list, AXL_KEY_STATUS, AXL_STATUS_DEST);
-  return AXL_SUCCESS;
+    /* mark full file list as not transfered */
+    kvtree_util_set_int(file_list, AXL_KEY_STATUS, AXL_STATUS_SOURCE);
+
+    return AXL_SUCCESS;
+#endif
+
+    return AXL_FAILURE;
+}
+
+int axl_async_test_datawarp(int id)
+{
+#ifdef HAVE_DATAWARP
+    /* assume transfer is complete */
+    int transfer_complete = 1;
+
+    int complete = 0;
+    int pending  = 0;
+    int deferred = 0;
+    int failed   = 0;
+
+    kvtree* file_list = kvtree_get_kv_int(axl_async_file_lists, AXL_KEY_HANDLE_UID, id);
+    kvtree* files     = kvtree_get(file_list, AXL_KEY_FILE);
+
+    /* iterate over files */
+    kvtree_elem* elem;
+    for (elem = kvtree_elem_first(files);
+         elem != NULL;
+         elem = kvtree_elem_next(elem))
+    {
+        kvtree* elem_hash = kvtree_elem_hash(elem);
+
+        int status;
+        kvtree_util_get_int(elem_hash, AXL_KEY_FILE_STATUS, &status);
+
+        switch (status) {
+            case AXL_STATUS_DEST:
+                break;
+            case AXL_STATUS_INPROG:
+                char* file = kvtree_elem_key(elem);
+
+                int test_complete;
+                int test_pending;
+                int test_deferred;
+                int test_failed;
+                int test = dw_query_file_stage(
+                    file,
+                    &test_complete,
+                    &test_pending,
+                    &test_deferred,
+                    &test_failed
+                );
+
+                if (test == 0) {
+                   complete += test_complete;
+                   pending  += test_pending;
+                   deferred += test_deferred;
+                   failed   += test_failed;
+
+                   int file_status = AXL_STATUS_INPROG;
+                   if (test_failed) {
+                      file_status = AXL_STATUS_ERROR;
+                   } else if (test_complete) {
+                      file_status = AXL_STATUS_DEST;
+                   }
+                   kvtree_util_set_int(elem_hash, AXL_KEY_FILE_STATUS, file_status);
+                } else {
+                   axl_abort(-1, "Datawarp failed with error %d @ %s:%d", -test, __FILE__, __LINE__);
+                }
+                break;
+            case AXL_STATUS_ERROR:
+            case AXL_STATUS_SOURCE:
+            default:
+                axl_abort(-1, "Wait called on file with invalid status @ %s:%d", __FILE__, __LINE__);
+        }
+    }
+
+    int status = AXL_STATUS_DEST;
+    if (failed != 0) {
+       status = AXL_STATUS_ERROR;
+    } else if (pending != 0 || deferred != 0) {
+       transfer_complete = 0;
+       status = AXL_STATUS_INPROG
+    }
+
+    /* record the transfer status */
+    kvtree_util_set_int(file_list, AXL_KEY_STATUS, status);
+
+    if (transfer_complete) {
+       return AXL_SUCCESS
+    }
+#endif
+
+    return AXL_FAILURE;
+}
+
+int axl_async_wait_datawarp(int id)
+{
+#ifdef HAVE_DATAWARP
+    /* Get the list of files */
+    int dw_wait       = 0;
+
+    kvtree* file_list = kvtree_get_kv_int(axl_async_file_lists, AXL_KEY_HANDLE_UID, id);
+    kvtree* files     = kvtree_get(file_list, AXL_KEY_FILE);
+
+    /* iterate over files */
+    kvtree_elem* elem = NULL;
+    for (elem = kvtree_elem_first(files);
+         elem != NULL;
+         elem = kvtree_elem_next(elem))
+    {
+        kvtree* elem_hash = kvtree_elem_hash(elem);
+
+        int status;
+        kvtree_util_get_int(elem_hash, AXL_KEY_FILE_STATUS, &status);
+
+        switch (status) {
+            case AXL_STATUS_DEST:
+                break;
+            case AXL_STATUS_INPROG:
+                /* Do the wait on each file */
+                char* file = kvtree_elem_key(elem);
+                dw_wait = dw_wait_file_stage(file);
+                if (dw_wait != 0) {
+                    axl_abort(-1,
+                        "Datawarp wait operation failed with error %d @ %s:%d",
+                        -dw_wait, __FILE__, __LINE__
+                    );
+                }
+                kvtree_util_set_int(elem_hash, AXL_KEY_FILE_STATUS, AXL_STATUS_DEST);
+                break;
+            case AXL_STATUS_SOURCE:
+            case AXL_STATUS_ERROR:
+            default:
+                axl_abort(-1,
+                    "Wait operation called on file with invalid status @ %s:%d",
+                    __FILE__, __LINE__
+                );
+        }
+    }
+
+    /* record transfer complete */
+    kvtree_util_set_int(file_list, AXL_KEY_STATUS, AXL_STATUS_DEST);
+    return AXL_SUCCESS;
 #else
-  return AXL_FAILURE;
+    return AXL_FAILURE;
 #endif
 }
 
-
-int axl_async_init_datawarp(){
-  return AXL_SUCCESS;
+int axl_async_init_datawarp()
+{
+    return AXL_SUCCESS;
 }
 
-int axl_async_finalize_datawarp(){
-  return AXL_SUCCESS;
+int axl_async_finalize_datawarp()
+{
+    return AXL_SUCCESS;
 }

--- a/src/axl_err.c
+++ b/src/axl_err.c
@@ -18,56 +18,56 @@
 int axl_debug;
 
 /* print message to stdout if axl_debug is set and it is >= level */
-void axl_dbg(int level, const char *fmt, ...)
+void axl_dbg(int level, const char* fmt, ...)
 {
-  /* get my hostname */
-  char hostname[256];
-  if (gethostname(hostname, sizeof(hostname)) != 0) {
-    /* TODO: error! */
-  }
+    /* get my hostname */
+    char hostname[256];
+    if (gethostname(hostname, sizeof(hostname)) != 0) {
+        /* TODO: error! */
+    }
+  
+    va_list argp;
+    if (level == 0 || (axl_debug > 0 && axl_debug >= level)) {
+        fprintf(stdout, "AXL %s: %s: ", AXL_VERSION, hostname);
+        va_start(argp, fmt);
+        vfprintf(stdout, fmt, argp);
+        va_end(argp);
+        fprintf(stdout, "\n");
+    }
+}
 
-  va_list argp;
-  if (level == 0 || (axl_debug > 0 && axl_debug >= level)) {
-    fprintf(stdout, "AXL %s: %s: ", AXL_VERSION, hostname);
+/* print error message to stdout */
+void axl_err(const char* fmt, ...)
+{
+    /* get my hostname */
+    char hostname[256];
+    if (gethostname(hostname, sizeof(hostname)) != 0) {
+        /* TODO: error! */
+    }
+  
+    va_list argp;
+    fprintf(stdout, "AXL %s ERROR: %s: ", AXL_VERSION, hostname);
     va_start(argp, fmt);
     vfprintf(stdout, fmt, argp);
     va_end(argp);
     fprintf(stdout, "\n");
-  }
-}
-
-/* print error message to stdout */
-void axl_err(const char *fmt, ...)
-{
-  /* get my hostname */
-  char hostname[256];
-  if (gethostname(hostname, sizeof(hostname)) != 0) {
-    /* TODO: error! */
-  }
-
-  va_list argp;
-  fprintf(stdout, "AXL %s ERROR: %s: ", AXL_VERSION, hostname);
-  va_start(argp, fmt);
-  vfprintf(stdout, fmt, argp);
-  va_end(argp);
-  fprintf(stdout, "\n");
 }
 
 /* print abort message and kill run */
-void axl_abort(int rc, const char *fmt, ...)
+void axl_abort(int rc, const char* fmt, ...)
 {
-  /* get my hostname */
-  char hostname[256];
-  if (gethostname(hostname, sizeof(hostname)) != 0) {
-    /* TODO: error! */
-  }
-
-  va_list argp;
-  fprintf(stderr, "AXL %s ABORT: %s: ", AXL_VERSION, hostname);
-  va_start(argp, fmt);
-  vfprintf(stderr, fmt, argp);
-  va_end(argp);
-  fprintf(stderr, "\n");
-
-  exit(rc);
+    /* get my hostname */
+    char hostname[256];
+    if (gethostname(hostname, sizeof(hostname)) != 0) {
+        /* TODO: error! */
+    }
+  
+    va_list argp;
+    fprintf(stderr, "AXL %s ABORT: %s: ", AXL_VERSION, hostname);
+    va_start(argp, fmt);
+    vfprintf(stderr, fmt, argp);
+    va_end(argp);
+    fprintf(stderr, "\n");
+  
+    exit(rc);
 }

--- a/src/axl_internal.h
+++ b/src/axl_internal.h
@@ -61,13 +61,13 @@ Note: these functions are taken directly from SCR
 */
 
 /* print message to stdout if axl_debug is set and it is >= level */
-void axl_dbg(int level, const char *fmt, ...);
+void axl_dbg(int level, const char* fmt, ...);
 
 /* print error message to stdout */
-void axl_err(const char *fmt, ...);
+void axl_err(const char* fmt, ...);
 
 /* print abort message and kill run */
-void axl_abort(int rc, const char *fmt, ...);
+void axl_abort(int rc, const char* fmt, ...);
 
 /*
 =========================================
@@ -84,7 +84,7 @@ Note: these functions are taken directly from SCR
  *
  * For example, tmpfs and ext4 support extents, NFS does not.
  */
-int axl_file_supports_fiemap(char *path);
+int axl_file_supports_fiemap(char* path);
 #endif
 
 /* returns user's current mode as determine by their umask */
@@ -112,8 +112,12 @@ ssize_t axl_read_attempt(const char* file, int fd, void* buf, size_t size);
 ssize_t axl_write_attempt(const char* file, int fd, const void* buf, size_t size);
 
 /* copy a file from src to dst */
-int axl_file_copy(const char* src_file, const char* dst_file,
-    unsigned long buf_size, int resume);
+int axl_file_copy(
+    const char* src_file,
+    const char* dst_file,
+    unsigned long buf_size,
+    int resume
+);
 
 /* opens, reads, and computes the crc32 value for the given filename */
 int axl_crc32(const char* filename, uLong* crc);
@@ -133,8 +137,8 @@ double axl_seconds();
 extern size_t axl_file_buf_size;
 
 int axl_compare_files_or_dirs(char *path1, char *path2);
-void axl_free(void* p);
 
+void axl_free(void* p);
 
 /*
  * This is an helper function to iterate though a file list for a given
@@ -150,8 +154,12 @@ void axl_free(void* p);
  *
  *    src or dst can be set to NULL if you don't care about the value.
  */
-kvtree_elem * axl_get_next_path(int id, kvtree_elem *elem, char **src,
-    char **dst);
+kvtree_elem* axl_get_next_path(
+    int id,
+    kvtree_elem* elem,
+    char** src,
+    char** dst
+);
 
 /* Clone of apsrintf().  See the standard asprintf() man page for details */
 int asprintf(char** strp, const char* fmt, ...);

--- a/src/axl_io.c
+++ b/src/axl_io.c
@@ -46,7 +46,8 @@
 // HAVE_STRUCT_STAT_ST_MTIME_USEC
 
 /* returns user's current mode as determine by their umask */
-mode_t axl_getmode(int read, int write, int execute) {
+mode_t axl_getmode(int read, int write, int execute)
+{
     /* lookup current mask and set it back */
     mode_t old_mask = umask(S_IWGRP | S_IWOTH);
     umask(old_mask);
@@ -68,7 +69,8 @@ mode_t axl_getmode(int read, int write, int execute) {
 }
 
 /* recursively create directory and subdirectories */
-int axl_mkdir(const char* dir, mode_t mode) {
+int axl_mkdir(const char* dir, mode_t mode)
+{
     /* consider it a success if we either create the directory
      * or we fail because it already exists */
     int tmp_rc = mkdir(dir, mode);
@@ -76,9 +78,9 @@ int axl_mkdir(const char* dir, mode_t mode) {
         return AXL_SUCCESS;
     }
 
-     /* failed to create the directory,
-      * we'll check the parent dir and try again */
-     int rc = AXL_SUCCESS;
+    /* failed to create the directory,
+     * we'll check the parent dir and try again */
+    int rc = AXL_SUCCESS;
 
     /* With dirname, either the original string may be modified or the function may return a
      * pointer to static storage which will be overwritten by the next call to dirname,
@@ -108,8 +110,8 @@ int axl_mkdir(const char* dir, mode_t mode) {
                 return AXL_SUCCESS;
             } else {
                 AXL_ERR("Creating directory: mkdir(%s, %x) path=%s errno=%d %s",
-                        dir, mode, path, errno, strerror(errno)
-                        );
+                    dir, mode, path, errno, strerror(errno)
+                );
                 rc = AXL_FAILURE;
             }
         }
@@ -125,18 +127,20 @@ int axl_mkdir(const char* dir, mode_t mode) {
 }
 
 /* delete a file */
-int axl_file_unlink(const char* file) {
+int axl_file_unlink(const char* file)
+{
     if (unlink(file) != 0) {
         AXL_DBG(2, "Failed to delete file: %s errno=%d %s",
-                file, errno, strerror(errno)
-                );
+            file, errno, strerror(errno)
+        );
         return AXL_FAILURE;
     }
     return AXL_SUCCESS;
 }
 
 /* open file with specified flags and mode, retry open a few times on failure */
-int axl_open(const char* file, int flags, ...) {
+int axl_open(const char* file, int flags, ...)
+{
     /* extract the mode (see man 2 open) */
     int mode_set = 0;
     mode_t mode = 0;
@@ -154,10 +158,11 @@ int axl_open(const char* file, int flags, ...) {
     } else {
         fd = open(file, flags);
     }
+
     if (fd < 0) {
         AXL_DBG(1, "Opening file: open(%s) errno=%d %s",
-                file, errno, strerror(errno)
-                );
+            file, errno, strerror(errno)
+        );
 
         /* try again */
         int tries = AXL_OPEN_TRIES;
@@ -178,11 +183,13 @@ int axl_open(const char* file, int flags, ...) {
                     );
         }
     }
+
     return fd;
 }
 
 /* reliable read from file descriptor (retries, if necessary, until hard error) */
-ssize_t axl_read(const char* file, int fd, void* buf, size_t size) {
+ssize_t axl_read(const char* file, int fd, void* buf, size_t size)
+{
     ssize_t n = 0;
     int retries = 10;
     while (n < size) {
@@ -203,13 +210,13 @@ ssize_t axl_read(const char* file, int fd, void* buf, size_t size) {
             if (retries) {
                 /* print an error and try again */
                 AXL_ERR("Error reading %s: read(%d, %x, %ld) errno=%d %s",
-                        file, fd, (char*) buf + n, size - n, errno, strerror(errno)
-                        );
+                    file, fd, (char*) buf + n, size - n, errno, strerror(errno)
+                );
             } else {
                 /* too many failed retries, give up */
                 AXL_ERR("Giving up read of %s: read(%d, %x, %ld) errno=%d %s",
-                        file, fd, (char*) buf + n, size - n, errno, strerror(errno)
-                        );
+                    file, fd, (char*) buf + n, size - n, errno, strerror(errno)
+                );
                 exit(1);
             }
         }
@@ -218,7 +225,8 @@ ssize_t axl_read(const char* file, int fd, void* buf, size_t size) {
 }
 
 /* make a good attempt to read from file (retries, if necessary, return error if fail) */
-ssize_t axl_read_attempt(const char* file, int fd, void* buf, size_t size) {
+ssize_t axl_read_attempt(const char* file, int fd, void* buf, size_t size)
+{
     ssize_t n = 0;
     int retries = 10;
     while (n < size) {
@@ -239,13 +247,13 @@ ssize_t axl_read_attempt(const char* file, int fd, void* buf, size_t size) {
             if (retries) {
                 /* print an error and try again */
                 AXL_ERR("Error reading file %s errno=%d %s",
-                        file, errno, strerror(errno)
-                        );
+                    file, errno, strerror(errno)
+                );
             } else {
                 /* too many failed retries, give up */
                 AXL_ERR("Giving up read on file %s errno=%d %s",
-                        file, errno, strerror(errno)
-                        );
+                    file, errno, strerror(errno)
+                );
                 return -1;
             }
         }
@@ -255,7 +263,8 @@ ssize_t axl_read_attempt(const char* file, int fd, void* buf, size_t size) {
 
 
 /* make a good attempt to write to file (retries, if necessary, return error if fail) */
-ssize_t axl_write_attempt(const char* file, int fd, const void* buf, size_t size) {
+ssize_t axl_write_attempt(const char* file, int fd, const void* buf, size_t size)
+{
     ssize_t n = 0;
     int retries = 10;
     while (n < size) {
@@ -277,13 +286,13 @@ ssize_t axl_write_attempt(const char* file, int fd, const void* buf, size_t size
             if (retries) {
                 /* print an error and try again */
                 AXL_ERR("Error writing file %s errno=%d %s",
-                        file, errno, strerror(errno)
-                        );
+                    file, errno, strerror(errno)
+                );
             } else {
                 /* too many failed retries, give up */
                 AXL_ERR("Giving up write of file %s errno=%d %s",
-                        file, errno, strerror(errno)
-                        );
+                    file, errno, strerror(errno)
+                );
                 return -1;
             }
         }
@@ -292,21 +301,22 @@ ssize_t axl_write_attempt(const char* file, int fd, const void* buf, size_t size
 }
 
 /* fsync and close file */
-int axl_close(const char* file, int fd) {
+int axl_close(const char* file, int fd)
+{
     /* fsync first */
     if (fsync(fd) < 0) {
         /* print warning that fsync failed */
         AXL_DBG(2, "Failed to fsync file descriptor: %s errno=%d %s",
-                file, errno, strerror(errno)
-                );
+            file, errno, strerror(errno)
+        );
     }
 
     /* now close the file */
     if (close(fd) != 0) {
         /* hit an error, print message */
         AXL_ERR("Closing file descriptor %d for file %s: errno=%d %s",
-                fd, file, errno, strerror(errno)
-                );
+            fd, file, errno, strerror(errno)
+        );
         return AXL_FAILURE;
     }
 
@@ -372,129 +382,129 @@ static void axl_stat_get_ctimes (const struct stat* sb, uint64_t* secs, uint64_t
 
 int axl_meta_encode(const char* file, kvtree* meta)
 {
-  struct stat statbuf;
-  int rc = lstat(file, &statbuf);
-  if (rc == 0) {
-    kvtree_util_set_unsigned_long(meta, "MODE", (unsigned long) statbuf.st_mode);
-    kvtree_util_set_unsigned_long(meta, "UID",  (unsigned long) statbuf.st_uid);
-    kvtree_util_set_unsigned_long(meta, "GID",  (unsigned long) statbuf.st_gid);
-    kvtree_util_set_unsigned_long(meta, "SIZE", (unsigned long) statbuf.st_size);
-
-    uint64_t secs, nsecs;
-    axl_stat_get_atimes(&statbuf, &secs, &nsecs);
-    kvtree_util_set_unsigned_long(meta, "ATIME_SECS",  (unsigned long) secs);
-    kvtree_util_set_unsigned_long(meta, "ATIME_NSECS", (unsigned long) nsecs);
-
-    axl_stat_get_ctimes(&statbuf, &secs, &nsecs);
-    kvtree_util_set_unsigned_long(meta, "CTIME_SECS",  (unsigned long) secs);
-    kvtree_util_set_unsigned_long(meta, "CTIME_NSECS", (unsigned long) nsecs);
-
-    axl_stat_get_mtimes(&statbuf, &secs, &nsecs);
-    kvtree_util_set_unsigned_long(meta, "MTIME_SECS",  (unsigned long) secs);
-    kvtree_util_set_unsigned_long(meta, "MTIME_NSECS", (unsigned long) nsecs);
-
-    return AXL_SUCCESS;
-  }
-  return AXL_FAILURE;
+    struct stat statbuf;
+    int rc = lstat(file, &statbuf);
+    if (rc == 0) {
+        kvtree_util_set_unsigned_long(meta, "MODE", (unsigned long) statbuf.st_mode);
+        kvtree_util_set_unsigned_long(meta, "UID",  (unsigned long) statbuf.st_uid);
+        kvtree_util_set_unsigned_long(meta, "GID",  (unsigned long) statbuf.st_gid);
+        kvtree_util_set_unsigned_long(meta, "SIZE", (unsigned long) statbuf.st_size);
+  
+        uint64_t secs, nsecs;
+        axl_stat_get_atimes(&statbuf, &secs, &nsecs);
+        kvtree_util_set_unsigned_long(meta, "ATIME_SECS",  (unsigned long) secs);
+        kvtree_util_set_unsigned_long(meta, "ATIME_NSECS", (unsigned long) nsecs);
+  
+        axl_stat_get_ctimes(&statbuf, &secs, &nsecs);
+        kvtree_util_set_unsigned_long(meta, "CTIME_SECS",  (unsigned long) secs);
+        kvtree_util_set_unsigned_long(meta, "CTIME_NSECS", (unsigned long) nsecs);
+  
+        axl_stat_get_mtimes(&statbuf, &secs, &nsecs);
+        kvtree_util_set_unsigned_long(meta, "MTIME_SECS",  (unsigned long) secs);
+        kvtree_util_set_unsigned_long(meta, "MTIME_NSECS", (unsigned long) nsecs);
+  
+        return AXL_SUCCESS;
+    }
+    return AXL_FAILURE;
 }
 
 int axl_meta_apply(const char* file, const kvtree* meta)
 {
-  int rc = AXL_SUCCESS;
-
-  /* set permission bits on file */
-  unsigned long mode_val;
-  if (kvtree_util_get_unsigned_long(meta, "MODE", &mode_val) == KVTREE_SUCCESS) {
-    mode_t mode = (mode_t) mode_val;
-
-    /* TODO: mask some bits here */
-
-    int chmod_rc = chmod(file, mode);
-    if (chmod_rc != 0) {
-      /* failed to set permissions */
-      axl_err("chmod(%s) failed: errno=%d %s @ %s:%d",
-        file, errno, strerror(errno), __FILE__, __LINE__
-      );
-      rc = AXL_FAILURE;
+    int rc = AXL_SUCCESS;
+  
+    /* set permission bits on file */
+    unsigned long mode_val;
+    if (kvtree_util_get_unsigned_long(meta, "MODE", &mode_val) == KVTREE_SUCCESS) {
+        mode_t mode = (mode_t) mode_val;
+  
+        /* TODO: mask some bits here */
+  
+        int chmod_rc = chmod(file, mode);
+        if (chmod_rc != 0) {
+            /* failed to set permissions */
+            AXL_ERR("chmod(%s) failed: errno=%d %s",
+                file, errno, strerror(errno)
+            );
+            rc = AXL_FAILURE;
+        }
     }
-  }
-
-  /* set uid and gid on file */
-  unsigned long uid_val = -1;
-  unsigned long gid_val = -1;
-  kvtree_util_get_unsigned_long(meta, "UID", &uid_val);
-  kvtree_util_get_unsigned_long(meta, "GID", &gid_val);
-  if (uid_val != -1 || gid_val != -1) {
-    /* got a uid or gid value, try to set them */
-    int chown_rc = chown(file, (uid_t) uid_val, (gid_t) gid_val);
-    if (chown_rc != 0) {
-      /* failed to set uid and gid */
-      axl_err("chown(%s, %lu, %lu) failed: errno=%d %s @ %s:%d",
-        file, uid_val, gid_val, errno, strerror(errno), __FILE__, __LINE__
-      );
-      rc = AXL_FAILURE;
+  
+    /* set uid and gid on file */
+    unsigned long uid_val = -1;
+    unsigned long gid_val = -1;
+    kvtree_util_get_unsigned_long(meta, "UID", &uid_val);
+    kvtree_util_get_unsigned_long(meta, "GID", &gid_val);
+    if (uid_val != -1 || gid_val != -1) {
+        /* got a uid or gid value, try to set them */
+        int chown_rc = chown(file, (uid_t) uid_val, (gid_t) gid_val);
+        if (chown_rc != 0) {
+            /* failed to set uid and gid */
+            AXL_ERR("chown(%s, %lu, %lu) failed: errno=%d %s",
+                file, uid_val, gid_val, errno, strerror(errno)
+            );
+            rc = AXL_FAILURE;
+        }
     }
-  }
-
-  /* can't set the size at this point, but we can check it */
-  unsigned long size;
-  if (kvtree_util_get_unsigned_long(meta, "SIZE", &size) == KVTREE_SUCCESS) {
-    /* got a size field in the metadata, stat the file */
-    struct stat statbuf;
-    int stat_rc = lstat(file, &statbuf);
-    if (stat_rc == 0) {
-      /* stat succeeded, check that sizes match */
-      if (size != statbuf.st_size) {
-        /* file size is not correct */
-        axl_err("file `%s' size is %lu expected %lu @ %s:%d",
-          file, (unsigned long) statbuf.st_size, size, __FILE__, __LINE__
-        );
-        rc = AXL_FAILURE;
-      }
-    } else {
-      /* failed to stat file */
-      axl_err("stat(%s) failed: errno=%d %s @ %s:%d",
-        file, errno, strerror(errno), __FILE__, __LINE__
-      );
-      rc = AXL_FAILURE;
+  
+    /* can't set the size at this point, but we can check it */
+    unsigned long size;
+    if (kvtree_util_get_unsigned_long(meta, "SIZE", &size) == KVTREE_SUCCESS) {
+        /* got a size field in the metadata, stat the file */
+        struct stat statbuf;
+        int stat_rc = lstat(file, &statbuf);
+        if (stat_rc == 0) {
+            /* stat succeeded, check that sizes match */
+            if (size != statbuf.st_size) {
+                /* file size is not correct */
+                AXL_ERR("file `%s' size is %lu expected %lu",
+                    file, (unsigned long) statbuf.st_size, size
+                );
+                rc = AXL_FAILURE;
+            }
+        } else {
+            /* failed to stat file */
+            AXL_ERR("stat(%s) failed: errno=%d %s",
+                file, errno, strerror(errno)
+            );
+            rc = AXL_FAILURE;
+        }
     }
-  }
-
-  /* set timestamps on file as last step */
-  unsigned long atime_secs  = 0;
-  unsigned long atime_nsecs = 0;
-  kvtree_util_get_unsigned_long(meta, "ATIME_SECS",  &atime_secs);
-  kvtree_util_get_unsigned_long(meta, "ATIME_NSECS", &atime_nsecs);
-
-  unsigned long mtime_secs  = 0;
-  unsigned long mtime_nsecs = 0;
-  kvtree_util_get_unsigned_long(meta, "MTIME_SECS",  &mtime_secs);
-  kvtree_util_get_unsigned_long(meta, "MTIME_NSECS", &mtime_nsecs);
-
-  if (atime_secs != 0 || atime_nsecs != 0 ||
-      mtime_secs != 0 || mtime_nsecs != 0)
-  {
-    /* fill in time structures */
-    struct timespec times[2];
-    times[0].tv_sec  = (time_t) atime_secs;
-    times[0].tv_nsec = (long)   atime_nsecs;
-    times[1].tv_sec  = (time_t) mtime_secs;
-    times[1].tv_nsec = (long)   mtime_nsecs;
-
-    /* set times with nanosecond precision using utimensat,
-     * assume path is relative to current working directory,
-     * if it's not absolute, and set times on link (not target file)
-     * if dest_path refers to a link */
-    int utime_rc = utimensat(AT_FDCWD, file, times, AT_SYMLINK_NOFOLLOW);
-    if (utime_rc != 0) {
-      axl_err("Failed to change timestamps on `%s' utimensat() errno=%d %s @ %s:%d",
-        file, errno, strerror(errno), __FILE__, __LINE__
-      );
-      rc = AXL_FAILURE;
+  
+    /* set timestamps on file as last step */
+    unsigned long atime_secs  = 0;
+    unsigned long atime_nsecs = 0;
+    kvtree_util_get_unsigned_long(meta, "ATIME_SECS",  &atime_secs);
+    kvtree_util_get_unsigned_long(meta, "ATIME_NSECS", &atime_nsecs);
+  
+    unsigned long mtime_secs  = 0;
+    unsigned long mtime_nsecs = 0;
+    kvtree_util_get_unsigned_long(meta, "MTIME_SECS",  &mtime_secs);
+    kvtree_util_get_unsigned_long(meta, "MTIME_NSECS", &mtime_nsecs);
+  
+    if (atime_secs != 0 || atime_nsecs != 0 ||
+        mtime_secs != 0 || mtime_nsecs != 0)
+    {
+        /* fill in time structures */
+        struct timespec times[2];
+        times[0].tv_sec  = (time_t) atime_secs;
+        times[0].tv_nsec = (long)   atime_nsecs;
+        times[1].tv_sec  = (time_t) mtime_secs;
+        times[1].tv_nsec = (long)   mtime_nsecs;
+    
+        /* set times with nanosecond precision using utimensat,
+         * assume path is relative to current working directory,
+         * if it's not absolute, and set times on link (not target file)
+         * if dest_path refers to a link */
+        int utime_rc = utimensat(AT_FDCWD, file, times, AT_SYMLINK_NOFOLLOW);
+        if (utime_rc != 0) {
+            axl_err("Failed to change timestamps on `%s' utimensat() errno=%d %s",
+                file, errno, strerror(errno)
+            );
+            rc = AXL_FAILURE;
+        }
     }
-  }
-
-  return rc;
+  
+    return rc;
 }
 
 /*
@@ -508,7 +518,7 @@ int axl_meta_apply(const char* file, const kvtree* meta)
 static unsigned long axl_debug_pause_after(void)
 {
     char* env = getenv("AXL_DEBUG_PAUSE_AFTER");
-    if (!env) {
+    if (! env) {
         return ULONG_MAX;
     }
     return strtoul(env, 0, 10);
@@ -517,13 +527,12 @@ static unsigned long axl_debug_pause_after(void)
 /* TODO: could perhaps use O_DIRECT here as an optimization */
 /* TODO: could apply compression/decompression here */
 /* copy src_file (full path) to dest_path and return new full path in dest_file */
-int axl_file_copy(const char* src_file, const char* dst_file,
-    unsigned long buf_size, int resume) {
-    off_t start_offset;
-    int flags;
-    unsigned long total_copied = 0;
-    unsigned long pause_after = axl_debug_pause_after();
-
+int axl_file_copy(
+    const char* src_file,
+    const char* dst_file,
+    unsigned long buf_size,
+    int resume)
+{
     /* check that we got something for a source file */
     if (src_file == NULL || strcmp(src_file, "") == 0) {
         AXL_ERR("Invalid source file");
@@ -542,25 +551,26 @@ int axl_file_copy(const char* src_file, const char* dst_file,
     int src_fd = axl_open(src_file, O_RDONLY);
     if (src_fd < 0) {
         AXL_ERR("Opening file to copy: axl_open(%s) errno=%d %s",
-                src_file, errno, strerror(errno)
-                );
+            src_file, errno, strerror(errno)
+        );
         return AXL_FAILURE;
     }
 
-    /* open dest_file for writing */
     mode_t mode_file = axl_getmode(1, 1, 0);
 
+    int flags;
     if (resume) {
         flags = O_WRONLY | O_CREAT | O_APPEND;
     } else {
         flags = O_WRONLY | O_CREAT | O_TRUNC;
     }
 
+    /* open dest_file for writing */
     int dst_fd = axl_open(dst_file, flags, mode_file);
     if (dst_fd < 0) {
         AXL_ERR("Opening file for writing: axl_open(%s) errno=%d %s",
-                dst_file, errno, strerror(errno)
-                );
+            dst_file, errno, strerror(errno)
+        );
         axl_close(src_file, src_fd);
         return AXL_FAILURE;
     }
@@ -579,8 +589,8 @@ int axl_file_copy(const char* src_file, const char* dst_file,
     char* buf = (char*) malloc(buf_size);
     if (buf == NULL) {
         AXL_ERR("Allocating memory: malloc(%llu) errno=%d %s",
-                buf_size, errno, strerror(errno)
-                );
+            buf_size, errno, strerror(errno)
+        );
         axl_close(dst_file, dst_fd);
         axl_close(src_file, src_fd);
         return AXL_FAILURE;
@@ -589,18 +599,22 @@ int axl_file_copy(const char* src_file, const char* dst_file,
     /* Resume the transfer to our destination file where we left off */
     if (resume) {
         /* Seek to the end of our destination file, while recording offset */
-        start_offset = lseek(dst_fd, 0, SEEK_END);
+        off_t start_offset = lseek(dst_fd, 0, SEEK_END);
 
         /* Set the src file position to the start_offset of dst file */
         if (lseek(src_fd, start_offset, SEEK_SET) != start_offset) {
             AXL_ERR("Couldn't seek src file errno=%d %s",
-                    errno, strerror(errno));
+                errno, strerror(errno)
+            );
             axl_free(buf);
             axl_close(dst_file, dst_fd);
             axl_close(src_file, src_fd);
             return AXL_FAILURE;
         }
     }
+
+    unsigned long total_copied = 0;
+    unsigned long pause_after = axl_debug_pause_after();
 
     /* write chunks */
     int copying = 1;
@@ -632,12 +646,10 @@ int axl_file_copy(const char* src_file, const char* dst_file,
             copying = 0;
             rc = AXL_FAILURE;
         }
-        total_copied += nread;
 
         /* Possibly pause our transfer for unit tests */
-        if (pause_after != ULONG_MAX && total_copied >= pause_after) {
-            while(1);
-        }
+        total_copied += nread;
+        while (pause_after != ULONG_MAX && total_copied >= pause_after);
     }
 
     /* free buffer */
@@ -662,14 +674,15 @@ int axl_file_copy(const char* src_file, const char* dst_file,
         }
     } else {
         /* unlink the file if the copy failed */
-        unlink(dst_file);
+        axl_file_unlink(dst_file);
     }
 
     return rc;
 }
 
 /* opens, reads, and computes the crc32 value for the given filename */
-int axl_crc32(const char* filename, uLong* crc) {
+int axl_crc32(const char* filename, uLong* crc)
+{
     /* check that we got a variable to write our answer to */
     if (crc == NULL) {
         return AXL_FAILURE;
@@ -682,8 +695,8 @@ int axl_crc32(const char* filename, uLong* crc) {
     int fd = axl_open(filename, O_RDONLY);
     if (fd < 0) {
         AXL_DBG(1, "Failed to open file to compute crc: %s errno=%d",
-                filename, errno
-                );
+            filename, errno
+        );
         return AXL_FAILURE;
     }
 
@@ -714,12 +727,12 @@ int axl_crc32(const char* filename, uLong* crc) {
 /* given a filename, return number of bytes in file */
 unsigned long axl_file_size(const char* file)
 {
-  /* get file size in bytes */
-  unsigned long bytes = 0;
-  struct stat stat_buf;
-  int stat_rc = stat(file, &stat_buf);
-  if (stat_rc == 0) {
-    bytes = stat_buf.st_size;
-  }
-  return bytes;
+    /* get file size in bytes */
+    unsigned long bytes = 0;
+    struct stat stat_buf;
+    int stat_rc = stat(file, &stat_buf);
+    if (stat_rc == 0) {
+        bytes = stat_buf.st_size;
+    }
+    return bytes;
 }

--- a/src/axl_pthread.c
+++ b/src/axl_pthread.c
@@ -26,7 +26,8 @@
 
 struct axl_work
 {
-    struct axl_work *next;
+    struct axl_work* next;
+
     /* The file element in the kvtree */
     kvtree_elem* elem;
 };
@@ -43,17 +44,17 @@ struct axl_pthread_data
     unsigned int threads;
 
     /* This struct is in a linked list */
-    struct axl_pthread_data *next;
+    struct axl_pthread_data* next;
 
     /* Lock to protect workqueue */
     pthread_mutex_t lock;
 
     /* Our workqueue */
-    struct axl_work *head;
-    struct axl_work *tail;
+    struct axl_work* head;
+    struct axl_work* tail;
 
     /* Array of our thread IDs */
-    pthread_t *tid;
+    pthread_t* tid;
 };
 
 /*
@@ -68,8 +69,8 @@ struct axl_pthread_data
  */
 struct axl_all_pthread_data
 {
-    struct axl_pthread_data *head;
-    struct axl_pthread_data *tail;
+    struct axl_pthread_data* head;
+    struct axl_pthread_data* tail;
 
     /* Lock to protect this data structure */
     pthread_mutex_t lock;
@@ -83,6 +84,7 @@ struct axl_all_pthread_data
 unsigned int axl_get_nprocs(void)
 {
     unsigned int cpu_threads;
+
 #if defined(__APPLE__)
     int count;
     size_t size = sizeof(count);
@@ -94,19 +96,18 @@ unsigned int axl_get_nprocs(void)
 #else
     cpu_threads = get_nprocs();
 #endif
+
     return cpu_threads;
 }
 
 /* Get the pthread data for a given AXL ID */
-struct axl_pthread_data *
-axl_pthread_data_lookup(int id)
+struct axl_pthread_data* axl_pthread_data_lookup(int id)
 {
-    struct axl_pthread_data *pdata;
-    struct axl_pthread_data *ret = NULL;
+    struct axl_pthread_data* ret = NULL;
 
     pthread_mutex_lock(&axl_all_pthread_data.lock);
 
-    pdata = axl_all_pthread_data.head;
+    struct axl_pthread_data* pdata = axl_all_pthread_data.head;
     while (pdata) {
         if (pdata->id == id) {
             /* Match */
@@ -118,17 +119,16 @@ axl_pthread_data_lookup(int id)
 
     pthread_mutex_unlock(&axl_all_pthread_data.lock);
 
-    /* No match */
     return ret;
 }
 
 /*
  * Add our new pdata to the list.
  */
-void
-axl_pthread_data_add(int id, struct axl_pthread_data *pdata)
+void axl_pthread_data_add(int id, struct axl_pthread_data* pdata)
 {
     pdata->id = id;
+
     pthread_mutex_lock(&axl_all_pthread_data.lock);
 
     if (!axl_all_pthread_data.head) {
@@ -139,17 +139,16 @@ axl_pthread_data_add(int id, struct axl_pthread_data *pdata)
        axl_all_pthread_data.tail->next = pdata;
        axl_all_pthread_data.tail = pdata;
     }
+
     pthread_mutex_unlock(&axl_all_pthread_data.lock);
 }
 
-void
-axl_pthread_data_remove(int id)
+void axl_pthread_data_remove(int id)
 {
-    struct axl_pthread_data *pdata, *prev = NULL;
-
     pthread_mutex_lock(&axl_all_pthread_data.lock);
 
-    pdata = axl_all_pthread_data.head;
+    struct axl_pthread_data* prev = NULL;
+    struct axl_pthread_data* pdata = axl_all_pthread_data.head;
     while (pdata) {
          if (pdata->id == id) {
             /*
@@ -170,28 +169,22 @@ axl_pthread_data_remove(int id)
         prev = pdata;
         pdata = pdata->next;
     }
+
     pthread_mutex_unlock(&axl_all_pthread_data.lock);
 }
 
 /* The actual pthread function */
-static void *
-axl_pthread_func(void *arg)
+static void* axl_pthread_func(void* arg)
 {
-    struct axl_pthread_data *pdata = arg;
-    struct axl_work *work;
-    int rc;
-    char *src, *dst;
-    kvtree_elem *elem;
-    kvtree *elem_hash;
-
     pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
 
+    struct axl_pthread_data* pdata = arg;
     while (1) {
         pthread_mutex_lock(&pdata->lock);
 
         /* Get a file to transfer */
-        work = pdata->head;
-        if (!work) {
+        struct axl_work* work = pdata->head;
+        if (! work) {
             /* No more work to do */
             pthread_mutex_unlock(&pdata->lock);
             break;
@@ -201,13 +194,19 @@ axl_pthread_func(void *arg)
             pthread_mutex_unlock(&pdata->lock);
         }
 
-        /* Lookup our filename */
-        elem = work->elem;
-        elem_hash = kvtree_elem_hash(elem);
-        src = kvtree_elem_key(elem);
+        /* Get kvtree for this file */
+        kvtree_elem* elem = work->elem;
+        kvtree* elem_hash = kvtree_elem_hash(elem);
+
+        /* Get source file name */
+        char* src = kvtree_elem_key(elem);
+
+        /* Lookup destination filename */
+        char* dst = NULL;
         kvtree_util_get_str(elem_hash, AXL_KEY_FILE_DEST, &dst);
 
-        rc = axl_file_copy(src, dst, axl_file_buf_size, pdata->resume);
+        /* Copy the file from soruce to destination */
+        int rc = axl_file_copy(src, dst, axl_file_buf_size, pdata->resume);
         AXL_DBG(2, "%s: Read and copied %s to %s, rc %d",
             __func__, src, dst, rc);
 
@@ -221,21 +220,19 @@ axl_pthread_func(void *arg)
         free(work);
 
         if (rc != AXL_SUCCESS) {
-            pthread_exit((void *) AXL_FAILURE);
+            pthread_exit((void*) AXL_FAILURE);
         }
     }
 
     return AXL_SUCCESS;
 }
 
-static struct axl_pthread_data *
-axl_pthread_create_thread_data(unsigned int threads)
+static struct axl_pthread_data* axl_pthread_create_thread_data(unsigned int threads)
 {
-    struct axl_pthread_data *pdata;
-
-    pdata = calloc(1, sizeof(*pdata));
-    if (!pdata)
+    struct axl_pthread_data* pdata = calloc(1, sizeof(*pdata));
+    if (! pdata) {
         return NULL;
+    }
 
     if (pthread_mutex_init(&pdata->lock, NULL) != 0) {
         free(pdata);
@@ -243,7 +240,7 @@ axl_pthread_create_thread_data(unsigned int threads)
     }
 
     pdata->tid = calloc(threads, sizeof(pdata->tid[0]));
-    if (!pdata->tid) {
+    if (! pdata->tid) {
         free(pdata);
         return NULL;
     }
@@ -254,16 +251,13 @@ axl_pthread_create_thread_data(unsigned int threads)
 }
 
 /* Free up our axl_pthread_data.  We assume no one is competing for the lock. */
-static void
-axl_pthread_free_pdata(struct axl_pthread_data *pdata)
+static void axl_pthread_free_pdata(struct axl_pthread_data* pdata)
 {
-    struct axl_work *work;
-
     /*
      * Free our workqueue item first (if any).  If our transfer completed
      * successfully, all workqueue entries would have already been freed.
      */
-    work = pdata->head;
+    struct axl_work* work = pdata->head;
     while (pdata->head) {
         work = pdata->head->next;
         free(pdata->head);
@@ -275,18 +269,16 @@ axl_pthread_free_pdata(struct axl_pthread_data *pdata)
 }
 
 /* Add a file to our workqueue.  We assume the lock is already held */
-static int
-axl_pthread_add_work(struct axl_pthread_data *pdata, kvtree_elem* elem)
+static int axl_pthread_add_work(struct axl_pthread_data* pdata, kvtree_elem* elem)
 {
-    struct axl_work *work;
-
-    work = calloc(1, sizeof(*work));
-    if (!work)
+    struct axl_work* work = calloc(1, sizeof(*work));
+    if (! work) {
         return AXL_FAILURE;
+    }
 
     work->elem = elem;
 
-    if (!pdata->head) {
+    if (! pdata->head) {
          /* First time we inserted into the workqueue */
         pdata->head = work;
         pdata->tail = work;
@@ -295,6 +287,7 @@ axl_pthread_add_work(struct axl_pthread_data *pdata, kvtree_elem* elem)
         pdata->tail->next = work;
         pdata->tail = work;
     }
+
     return AXL_SUCCESS;
 }
 
@@ -302,20 +295,17 @@ axl_pthread_add_work(struct axl_pthread_data *pdata, kvtree_elem* elem)
  * Create and wakeup all our threads to start transferring the files in
  * the workqueue.
  */
-static int
-axl_pthread_run(struct axl_pthread_data *pdata)
+static int axl_pthread_run(struct axl_pthread_data* pdata)
 {
     int i;
-    int rc;
-    int final_rc = AXL_SUCCESS;
-
     for (i = 0; i < pdata->threads; i++) {
-        rc = pthread_create(&pdata->tid[i], NULL, &axl_pthread_func, pdata);
-        if (rc != 0)
-            return rc;
+        int rc = pthread_create(&pdata->tid[i], NULL, &axl_pthread_func, pdata);
+        if (rc != 0) {
+            return AXL_FAILURE;
+        }
     }
 
-    return final_rc;
+    return AXL_SUCCESS;
 }
 
 /*
@@ -326,8 +316,6 @@ static int __axl_pthread_start (int id, int resume)
 {
     /* assume we'll succeed */
     int rc = AXL_SUCCESS;
-    struct axl_pthread_data *pdata;
-    unsigned int file_count, threads, cpu_threads;
 
     /* get pointer to file list for this dataset */
     kvtree* file_list = axl_kvtrees[id];
@@ -335,24 +323,29 @@ static int __axl_pthread_start (int id, int resume)
     /* mark dataset as in progress */
     kvtree_util_set_int(file_list, AXL_KEY_STATUS, AXL_STATUS_INPROG);
 
-    kvtree_elem* elem = NULL;
+    /* Get number of files being transferred */
     kvtree* files = kvtree_get(file_list, AXL_KEY_FILES);
-    file_count = kvtree_size(files);
+    unsigned int file_count = kvtree_size(files);
 
     /* Get number of hardware threads */
-    cpu_threads = axl_get_nprocs();
+    unsigned int cpu_threads = axl_get_nprocs();
 
-    threads = AXL_MIN(cpu_threads, AXL_MIN(file_count, MAX_THREADS));
+    unsigned int threads = AXL_MIN(cpu_threads, AXL_MIN(file_count, MAX_THREADS));
 
     /* Create the data structure for our threads */
-    pdata = axl_pthread_create_thread_data(threads);
-    if (!pdata)
+    struct axl_pthread_data* pdata = axl_pthread_create_thread_data(threads);
+    if (! pdata) {
         return AXL_FAILURE;
+    }
     pdata->resume = resume;
 
     axl_pthread_data_add(id, pdata);
 
-    for (elem = kvtree_elem_first(files); elem != NULL; elem = kvtree_elem_next(elem)) {
+    kvtree_elem* elem = NULL;
+    for (elem = kvtree_elem_first(files);
+         elem != NULL;
+         elem = kvtree_elem_next(elem))
+    {
         /* get the hash for this file */
         kvtree* elem_hash = kvtree_elem_hash(elem);
 
@@ -401,9 +394,7 @@ int axl_pthread_resume (int id)
 
 int axl_pthread_test (int id)
 {
-    struct axl_pthread_data *pdata;
-
-    pdata = axl_pthread_data_lookup(id);
+    struct axl_pthread_data* pdata = axl_pthread_data_lookup(id);
     assert(pdata);
 
     /* Is there still work in the workqueue? */
@@ -417,27 +408,26 @@ int axl_pthread_test (int id)
 
 int axl_pthread_wait (int id)
 {
+    int rc = AXL_SUCCESS;
+
     /* get pointer to file list for this dataset */
     kvtree* file_list = axl_kvtrees[id];
-    struct axl_pthread_data *pdata = NULL;
-    int rc;
-    int final_rc = AXL_SUCCESS;
-    int i;
-    void *rc_ptr = NULL;
 
-    pdata = axl_pthread_data_lookup(id);
-    if (!pdata) {
+    struct axl_pthread_data* pdata = axl_pthread_data_lookup(id);
+    if (! pdata) {
         /* Did they call AXL_Cancel() and then AXL_Wait()? */
-        AXL_ERR("No pthread data\n");
+        AXL_ERR("No pthread data");
         return AXL_FAILURE;
     }
 
     /* All our threads are now started.  Wait for them to finish */
+    int i;
     for (i = 0; i < pdata->threads; i++) {
-        rc = pthread_join(pdata->tid[i], &rc_ptr);
-        if (rc != 0) {
-                AXL_ERR("pthread_join(%d) failed (%d)", i, rc);
-                return AXL_FAILURE;
+        void* rc_ptr = NULL;
+        int tmp_rc = pthread_join(pdata->tid[i], &rc_ptr);
+        if (tmp_rc != 0) {
+            AXL_ERR("pthread_join(%d) failed (%d)", i, rc);
+            return AXL_FAILURE;
         }
 
         /*
@@ -446,14 +436,15 @@ int axl_pthread_wait (int id)
          * thread was canceled, that totally valid and fine.
          */
         if (rc_ptr != PTHREAD_CANCELED) {
-            rc = (int) ((unsigned long) rc_ptr);
-            if (rc) {
-                AXL_ERR("pthread join rc_ptr was set as %d\n", rc);
-                final_rc |= AXL_FAILURE;
+            tmp_rc = (int) ((unsigned long) rc_ptr);
+            if (tmp_rc) {
+                AXL_ERR("pthread join rc_ptr was set as %d", rc);
+                rc = AXL_FAILURE;
             }
         }
     }
-    if (final_rc != AXL_SUCCESS) {
+
+    if (rc != AXL_SUCCESS) {
         AXL_ERR("Couldn't join all threads");
         return AXL_FAILURE;
     }
@@ -469,46 +460,46 @@ int axl_pthread_wait (int id)
 
 int axl_pthread_cancel (int id)
 {
-    /* get pointer to file list for this dataset */
-    struct axl_pthread_data *pdata;
-    int rc = 0;
-    int i;
-    void *rc_ptr;
+    int rc = AXL_SUCCESS;
 
-    pdata = axl_pthread_data_lookup(id);
+    /* get pointer to pthread struct for this dataset */
+    struct axl_pthread_data* pdata = axl_pthread_data_lookup(id);
     assert(pdata);
 
+    int i;
     for (i = 0; i < pdata->threads; i++) {
         /* send the thread a cancellation request */
-        int rc = pthread_cancel(pdata->tid[i]);
-        if (rc) {
-            AXL_ERR("pthread_cancel failed, rc %d\n");
+        int tmp_rc = pthread_cancel(pdata->tid[i]);
+        if (tmp_rc) {
+            AXL_ERR("pthread_cancel failed, rc %d");
+            rc = AXL_FAILURE;
             break;
         }
 
         /* wait for the thread to actually exit */
+        void* rc_ptr;
         pthread_join(pdata->tid[i], &rc_ptr);
         if (rc_ptr != 0 && rc_ptr != PTHREAD_CANCELED) {
             AXL_ERR("pthread_join failed, rc_ptr %p", rc_ptr);
-            rc |= (int) ((unsigned long) rc_ptr);
+            rc = AXL_FAILURE;
         }
     }
-    if (rc != 0) {
-        AXL_ERR("Bad return code from canceling a thread\n");
+
+    if (rc != AXL_SUCCESS) {
+        AXL_ERR("Bad return code from canceling a thread");
     }
+
     return rc;
 }
 
 void axl_pthread_free (int id)
 {
-    struct axl_pthread_data *pdata;
-
     /*
      * pdata should have been freed in AXL_Wait(), but maybe they just did
      * an AXL_Cancel() and then an AXL_Free().  If so, pdata will be set
      * and we should free it.
      */
-    pdata = axl_pthread_data_lookup(id);
+    struct axl_pthread_data* pdata = axl_pthread_data_lookup(id);
     if (pdata) {
         axl_pthread_data_remove(id);
         axl_pthread_free_pdata(pdata);

--- a/src/axl_sync.c
+++ b/src/axl_sync.c
@@ -16,7 +16,10 @@ int __axl_sync_start (int id, int resume)
     /* transfer each of my files and fill in summary data structure */
     kvtree_elem* elem = NULL;
     kvtree* files = kvtree_get(file_list, AXL_KEY_FILES);
-    for (elem = kvtree_elem_first(files); elem != NULL; elem = kvtree_elem_next(elem)) {
+    for (elem = kvtree_elem_first(files);
+         elem != NULL;
+         elem = kvtree_elem_next(elem))
+    {
         /* get the filename */
         char* source = kvtree_elem_key(elem);
 
@@ -42,8 +45,8 @@ int __axl_sync_start (int id, int resume)
             rc = AXL_FAILURE;
         }
         AXL_DBG(2, "axl_sync_start: Read and copied %s to %s with success code %d",
-                source, destination, tmp_rc
-                );
+            source, destination, tmp_rc
+        );
     }
 
     /* mark this id as either done or error */

--- a/src/axl_util.c
+++ b/src/axl_util.c
@@ -10,6 +10,8 @@
 
 #include "axl_internal.h"
 
+size_t axl_file_buf_size;
+
 /* returns the current linux timestamp (secs + usecs since epoch) as a double */
 double axl_seconds()
 {
@@ -19,11 +21,10 @@ double axl_seconds()
   return secs;
 }
 
-size_t axl_file_buf_size;
-
 /* caller really passes in a void**, but we define it as just void* to avoid printing
  * a bunch of warnings */
-void axl_free(void* p) {
+void axl_free(void* p)
+{
     /* verify that we got a valid pointer to a pointer */
     if (p != NULL) {
         /* free memory if there is any */
@@ -95,9 +96,9 @@ int asprintf(char** strp, const char* fmt, ...)
  * This is an helper function to iterate though a file list for a given
  * AXL ID.  Usage:
  *
- *    char *src;
- *    char *dst;
- *    char *kvtree_elem *elem = NULL;
+ *    char* src;
+ *    char* dst;
+ *    char* kvtree_elem *elem = NULL;
  *
  *    while ((elem = axl_get_next_path(id, elem, &src, &dst))) {
  *        printf("src %s, dst %s\n", src, dst);
@@ -105,29 +106,20 @@ int asprintf(char** strp, const char* fmt, ...)
  *
  *    src or dst can be set to NULL if you don't care about the value.
  */
-kvtree_elem *
-axl_get_next_path(int id, kvtree_elem *elem, char **src, char **dst)
+kvtree_elem* axl_get_next_path(int id, kvtree_elem* elem, char** src, char** dst)
 {
-    /* lookup transfer info for the given id */
-    kvtree* file_list;
-    kvtree* files;
-    kvtree* elem_hash;
+    if (! elem) {
+        /* lookup transfer info for the given id */
+        kvtree* file_list = axl_kvtrees[id];
+        if (! file_list) {
+            return NULL;
+        }
 
-    file_list = axl_kvtrees[id];
-    if (!file_list) {
-        return NULL;
-    }
-
-    files = kvtree_get(file_list, AXL_KEY_FILES);
-
-    if (!elem) {
+        kvtree* files = kvtree_get(file_list, AXL_KEY_FILES);
         elem = kvtree_elem_first(files);
     } else {
         elem = kvtree_elem_next(elem);
     }
-
-    /* get hash for this file */
-    elem_hash = kvtree_elem_hash(elem);
 
     if (src) {
         *src = kvtree_elem_key(elem);
@@ -135,6 +127,7 @@ axl_get_next_path(int id, kvtree_elem *elem, char **src, char **dst)
 
     if (dst) {
         /* get destination for this file */
+        kvtree* elem_hash = kvtree_elem_hash(elem);
         kvtree_util_get_str(elem_hash, AXL_KEY_FILE_DEST, dst);
     }
 


### PR DESCRIPTION
- Update AXL to have a more self-consistent style and better match with other veloc components.
- Since a caller should always call wait, including after a test, rely on wait to rename files instead of doing it both test and wait.