### PR TITLE
implement config get interface

### DIFF
--- a/src/axl.c
+++ b/src/axl.c
@@ -362,7 +362,7 @@ static kvtree* AXL_Config_Set(const kvtree* config)
       if (kvtree_util_get_bytecount(config,
         AXL_KEY_CONFIG_FILE_BUF_SIZE, &ul) == KVTREE_SUCCESS)
       {
-        axl_file_buf_size = (int) ul;
+        axl_file_buf_size = (size_t) ul;
         if (axl_file_buf_size != ul) {
           char* value;
           kvtree_util_get_str(config, AXL_KEY_CONFIG_FILE_BUF_SIZE, &value);

--- a/src/axl.c
+++ b/src/axl.c
@@ -333,6 +333,7 @@ int AXL_Config(const kvtree* config)
     if (config != NULL)
     {
       const kvtree_elem* elem;
+      unsigned long ul;
 
       /* dummy variables for options not actually supported (anymore) */
       double axl_flush_async_bw = 0.0;
@@ -341,12 +342,30 @@ int AXL_Config(const kvtree* config)
 
       /* read out all options we know about */
       /* TODO: this could be turned into a list of structs */
-      kvtree_util_get_double(config, AXL_KEY_CONFIG_FLUSH_ASYNC_BW,
-                             &axl_flush_async_bw);
+      if (kvtree_util_get_bytecount(config, AXL_KEY_CONFIG_FLUSH_ASYNC_BW,
+                                    &ul) == KVTREE_SUCCESS) {
+        axl_flush_async_bw = (double) ul;
+        if (axl_flush_async_bw != ul) {
+          char *value;
+          kvtree_util_get_str(config, AXL_KEY_CONFIG_FLUSH_ASYNC_BW, &value);
+          fprintf(stderr, "Value %s passed for %s exceeds int range\n",
+                  value, AXL_KEY_CONFIG_FLUSH_ASYNC_BW);
+          retval = AXL_FAILURE;
+        }
+      }
       kvtree_util_get_double(config, AXL_KEY_CONFIG_FLUSH_ASYNC_PERCENT,
                              &axl_flush_async_percent);
-      kvtree_util_get_bytecount(config, AXL_KEY_CONFIG_FILE_BUF_SIZE,
-                                &axl_file_buf_size);
+      if (kvtree_util_get_bytecount(config, AXL_KEY_CONFIG_FILE_BUF_SIZE,
+                                    &ul) == KVTREE_SUCCESS) {
+        axl_file_buf_size = (int) ul;
+        if (axl_file_buf_size != ul) {
+          char *value;
+          kvtree_util_get_str(config, AXL_KEY_CONFIG_FILE_BUF_SIZE, &value);
+          fprintf(stderr, "Value %s passed for %s exceeds int range\n",
+                  value, AXL_KEY_CONFIG_FILE_BUF_SIZE);
+          retval = AXL_FAILURE;
+        }
+      }
       kvtree_util_get_int(config, AXL_KEY_CONFIG_CRC_ON_FLUSH,
                           &axl_crc_on_flush);
       kvtree_util_get_int(config, AXL_KEY_CONFIG_DEBUG, &axl_debug);

--- a/src/axl.c
+++ b/src/axl.c
@@ -310,9 +310,8 @@ int AXL_Finalize (void)
     return rc;
 }
 
-
-/** Set a AXL config parameters */
-kvtree* AXL_Config(const kvtree* config)
+/** Actual function to set config parameters */
+static kvtree* AXL_Config_Set(const kvtree* config)
 {
   kvtree* retval = (kvtree*)(config);
 
@@ -425,6 +424,48 @@ kvtree* AXL_Config(const kvtree* config)
   }
 
   return retval;
+}
+
+/** Actual function to get config parameters */
+static kvtree* AXL_Config_Get(void)
+{
+    kvtree* config = kvtree_new();
+
+    if(config != NULL) {
+        int success = 1; /* all values could be set? */
+
+        /* dummy variables for options not actually supported (anymore):
+         * AXL_KEY_CONFIG_FLUSH_ASYNC_BW
+         * AXL_KEY_CONFIG_FLUSH_ASYNC_PERCENT
+         * AXL_KEY_CONFIG_CRC_ON_FLUSH
+         */
+        success &= kvtree_util_set_bytecount(config,
+                                             AXL_KEY_CONFIG_FILE_BUF_SIZE,
+                                             (unsigned long)axl_file_buf_size)
+                     == KVTREE_SUCCESS;
+        success &= kvtree_util_set_int(config, AXL_KEY_CONFIG_DEBUG, axl_debug)
+                     == KVTREE_SUCCESS;
+        success &= kvtree_util_set_int(config, AXL_KEY_CONFIG_MKDIR,
+                                       axl_make_directories) == KVTREE_SUCCESS;
+        success &= kvtree_util_set_int(config, AXL_KEY_CONFIG_COPY_METADATA,
+                                       axl_copy_metadata) == KVTREE_SUCCESS;
+
+        if (!success) {
+            kvtree_delete(&config);
+        }
+    }
+
+    return config;
+}
+
+/** Set a AXL config parameters */
+kvtree* AXL_Config(const kvtree* config)
+{
+    if (config != NULL) {
+        return AXL_Config_Set(config);
+    } else {
+        return AXL_Config_Get();
+    }
 }
 
 

--- a/src/axl.c
+++ b/src/axl.c
@@ -400,7 +400,7 @@ static kvtree* AXL_Config_Set(const kvtree* config)
         /* check against known options */
         const char** opt;
         int found = 0;
-        for (opt = known_options; opt; opt++) {
+        for (opt = known_options; *opt != NULL; opt++) {
           if (strcmp(*opt, kvtree_elem_key(elem)) == 0) {
             found = 1;
             break;

--- a/src/axl.c
+++ b/src/axl.c
@@ -312,9 +312,9 @@ int AXL_Finalize (void)
 
 
 /** Set a AXL config parameters */
-int AXL_Config(const kvtree* config)
+kvtree* AXL_Config(const kvtree* config)
 {
-  int retval = AXL_SUCCESS;
+  kvtree* retval = (kvtree*)(config);
 
   static int configured = 0;
   static const char* known_options[] = {
@@ -327,6 +327,11 @@ int AXL_Config(const kvtree* config)
     AXL_KEY_CONFIG_COPY_METADATA,
     NULL
   };
+
+  /* TODO: implement getting configuration options back */
+  if (config == NULL) {
+    return NULL;
+  }
 
   if (! configured) {
     if (config != NULL) {
@@ -348,7 +353,7 @@ int AXL_Config(const kvtree* config)
           AXL_ERR("Value '%s' passed for %s exceeds int range",
             value, AXL_KEY_CONFIG_FLUSH_ASYNC_BW
           );
-          retval = AXL_FAILURE;
+          retval = NULL;
         }
       }
 
@@ -365,7 +370,7 @@ int AXL_Config(const kvtree* config)
           AXL_ERR("Value '%s' passed for %s exceeds int range",
             value, AXL_KEY_CONFIG_FILE_BUF_SIZE
           );
-          retval = AXL_FAILURE;
+          retval = NULL;
         }
       }
 
@@ -407,7 +412,7 @@ int AXL_Config(const kvtree* config)
             kvtree_elem_key(elem),
             kvtree_elem_key(kvtree_elem_first(kvtree_elem_hash(elem)))
           );
-          retval = AXL_FAILURE;
+          retval = NULL;
         }
       }
     }
@@ -416,7 +421,7 @@ int AXL_Config(const kvtree* config)
     configured = 1;
   } else {
     AXL_ERR("Already configured");
-    retval = AXL_FAILURE;
+    retval = NULL;
   }
 
   return retval;

--- a/src/axl.h
+++ b/src/axl.h
@@ -1,8 +1,6 @@
 #ifndef AXL_H
 #define AXL_H
 
-#include "kvtree.h"
-
 /* enable C++ codes to include this header directly */
 #ifdef __cplusplus
 extern "C" {
@@ -94,6 +92,7 @@ int AXL_Finalize (void);
 int __AXL_Create (axl_xfer_t xtype, const char* name, const char* state_file);
 
 /** Configure AXL options */
+typedef struct kvtree_t kvtree;
 int AXL_Config(
   const kvtree* config        /** [IN] - kvtree of options */
 );

--- a/src/axl.h
+++ b/src/axl.h
@@ -1,6 +1,8 @@
 #ifndef AXL_H
 #define AXL_H
 
+#include "kvtree.h"
+
 /* enable C++ codes to include this header directly */
 #ifdef __cplusplus
 extern "C" {
@@ -23,6 +25,15 @@ extern "C" {
 /** \file axl.h
  *  \ingroup axl
  *  \brief asynchronous transfer library */
+
+/** AXL configuration options */
+#define AXL_KEY_CONFIG_FLUSH_ASYNC_BW "FLUSH_ASYNC_BW" /* UNUSED */
+#define AXL_KEY_CONFIG_FLUSH_ASYNC_PERCENT "FLUSH_ASYNC_PERCENT" /* UNUSED */
+#define AXL_KEY_CONFIG_FILE_BUF_SIZE "FILE_BUF_SIZE"
+#define AXL_KEY_CONFIG_CRC_ON_FLUSH "CRC_ON_FLUSH" /* UNUSED */
+#define AXL_KEY_CONFIG_DEBUG "DEBUG"
+#define AXL_KEY_CONFIG_MKDIR "MKDIR"
+#define AXL_KEY_CONFIG_COPY_METADATA "COPY_METADATA"
 
 /** Supported AXL transfer methods
  * Note that DW, BBAPI, and CPPR must be found at compile time */
@@ -81,6 +92,11 @@ int AXL_Finalize (void);
 #define AXL_Create(type, name, ...) \
         __AXL_Create(type, name, GET_ARG0(__VA_ARGS__))
 int __AXL_Create (axl_xfer_t xtype, const char* name, const char* state_file);
+
+/** Configure AXL options */
+int AXL_Config(
+  const kvtree* config        /** [IN] - kvtree of options */
+);
 
 /** Add a file to an existing transfer handle */
 int AXL_Add (int id, const char* source, const char* destination);

--- a/src/axl.h
+++ b/src/axl.h
@@ -91,9 +91,20 @@ int AXL_Finalize (void);
         __AXL_Create(type, name, GET_ARG0(__VA_ARGS__))
 int __AXL_Create (axl_xfer_t xtype, const char* name, const char* state_file);
 
-/** Configure AXL options */
-typedef struct kvtree_t kvtree;
-int AXL_Config(
+/**
+ * Get/set AXL configuration values.
+ *
+ * config: The new configuration.  Global variables are in top level of
+ *              the tree, and per-ID values are subtrees.  If config=NULL,
+ *              then return a kvtree with all the configuration values (globals
+ *              and all per-ID trees).
+ *
+ * Return value: If config != NULL, then return config on success.  If
+ *                      config=NULL (you're querying the config) then return
+ *                      a new kvtree on success.  Return NULL on any failures.
+ */
+typedef struct kvtree_struct kvtree;
+kvtree* AXL_Config(
   const kvtree* config        /** [IN] - kvtree of options */
 );
 

--- a/src/axl_internal.h
+++ b/src/axl_internal.h
@@ -17,7 +17,7 @@
 /*
  * A list of pointers to kvtrees, indexed by AXL ID.
  */
-kvtree** axl_kvtrees;
+extern kvtree** axl_kvtrees;
 
 /* current debug level for AXL library,
  * set in AXL_Init used in axl_dbg */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 ###############
 # Build tests
 ###############
+INCLUDE_DIRECTORIES(${PROJECT_BINARY_DIR})
 
 LIST(APPEND axl_test_srcs
     axl_cp.c
@@ -10,8 +11,10 @@ LIST(APPEND axl_test_srcs
 # SET(CMAKE_BUILD_TYPE Debug)
 
 ADD_EXECUTABLE(axl_cp ${axl_test_srcs})
+ADD_EXECUTABLE(test_config test_config.c)
 
 TARGET_LINK_LIBRARIES(axl_cp axl)
+TARGET_LINK_LIBRARIES(test_config axl)
 
 ################
 # Add tests to ctest
@@ -42,6 +45,8 @@ IF(BBAPI_FOUND)
     # Values found through experimentation.
     ADD_TEST(bbapi_resume_test test_axl.sh -n 300 -c 3 -U  bbapi)
 ENDIF(BBAPI_FOUND)
+
+ADD_TEST(test_config test_config)
 
 ####################
 # make a verbose "test" target named "check"

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -1,0 +1,101 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "axl.h"
+#include "axl_internal.h"
+
+#include "kvtree.h"
+#include "kvtree_util.h"
+
+int
+main(void) {
+    int rc;
+    char *state_file = NULL;
+    kvtree* axl_config_values = kvtree_new();
+
+    size_t old_axl_file_buf_size = axl_file_buf_size;
+    int old_axl_debug = axl_debug;
+    int old_axl_make_directories = axl_make_directories;
+    int old_axl_copy_metadata = axl_copy_metadata;
+
+    rc = AXL_Init(state_file);
+    if (rc != AXL_SUCCESS) {
+        printf("AXL_Init() failed (error %d)\n", rc);
+        return rc;
+    }
+
+    /* check AXL configuration settings */
+    rc = kvtree_util_set_bytecount(axl_config_values,
+                                   AXL_KEY_CONFIG_FILE_BUF_SIZE,
+                                   old_axl_file_buf_size + 1);
+    if (rc != KVTREE_SUCCESS) {
+        printf("kvtree_util_set_bytecount failed (error %d)\n", rc);
+        return rc;
+    }
+    rc = kvtree_util_set_int(axl_config_values, AXL_KEY_CONFIG_DEBUG,
+                             !old_axl_debug);
+    if (rc != KVTREE_SUCCESS) {
+        printf("kvtree_util_set_int failed (error %d)\n", rc);
+        return rc;
+    }
+    rc = kvtree_util_set_int(axl_config_values, AXL_KEY_CONFIG_MKDIR,
+                             !old_axl_make_directories);
+    if (rc != KVTREE_SUCCESS) {
+        printf("kvtree_util_set_int failed (error %d)\n", rc);
+        return rc;
+    }
+    rc = kvtree_util_set_int(axl_config_values, AXL_KEY_CONFIG_COPY_METADATA,
+                             !old_axl_copy_metadata);
+    if (rc != KVTREE_SUCCESS) {
+        printf("kvtree_util_set_int failed (error %d)\n", rc);
+        return rc;
+    }
+
+    printf("Configuring AXL...\n");
+    rc = AXL_Config(axl_config_values);
+    if (rc != AXL_SUCCESS) {
+        printf("AXL_Config() failed (error %d)\n", rc);
+        return rc;
+    }
+
+    printf("Configuring AXL a second time (this should fail)...\n");
+    rc = AXL_Config(axl_config_values);
+    if (rc == AXL_SUCCESS) {
+        printf("AXL_Config() succeeded unexpectedly (error %d)\n", rc);
+        return rc;
+    }
+
+    if (axl_file_buf_size != old_axl_file_buf_size + 1) {
+        printf("AXL_Config() failed to set %s: %lu != %lu\n",
+               AXL_KEY_CONFIG_FILE_BUF_SIZE, (long unsigned)axl_file_buf_size,
+               (long unsigned)(old_axl_file_buf_size + 1));
+        return EXIT_FAILURE;
+    }
+
+    if (axl_debug != !old_axl_debug) {
+        printf("AXL_Config() failed to set %s: %d != %d\n",
+               AXL_KEY_CONFIG_DEBUG, axl_debug, !old_axl_debug);
+        return EXIT_FAILURE;
+    }
+
+    if (axl_make_directories != !old_axl_make_directories) {
+        printf("AXL_Config() failed to set %s: %d != %d\n",
+               AXL_KEY_CONFIG_MKDIR, axl_make_directories,
+               !old_axl_make_directories);
+        return EXIT_FAILURE;
+    }
+
+    if (axl_copy_metadata != !old_axl_copy_metadata) {
+        printf("AXL_Config() failed to set %s: %d != %d\n",
+               AXL_KEY_CONFIG_COPY_METADATA, axl_copy_metadata,
+               !old_axl_copy_metadata);
+        return EXIT_FAILURE;
+    }
+
+    rc = AXL_Finalize();
+    if (rc != AXL_SUCCESS) {
+        printf("AXL_Finalize() failed (error %d)\n", rc);
+        return rc;
+    }
+
+    return AXL_SUCCESS;
+}

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -51,17 +51,15 @@ main(void) {
     }
 
     printf("Configuring AXL...\n");
-    rc = AXL_Config(axl_config_values);
-    if (rc != AXL_SUCCESS) {
-        printf("AXL_Config() failed (error %d)\n", rc);
-        return rc;
+    if (AXL_Config(axl_config_values) == NULL) {
+        printf("AXL_Config() failed\n");
+        return EXIT_FAILURE;
     }
 
     printf("Configuring AXL a second time (this should fail)...\n");
-    rc = AXL_Config(axl_config_values);
-    if (rc == AXL_SUCCESS) {
-        printf("AXL_Config() succeeded unexpectedly (error %d)\n", rc);
-        return rc;
+    if (AXL_Config(axl_config_values) != NULL) {
+        printf("AXL_Config() succeeded unexpectedly\n");
+        return EXIT_FAILURE;
     }
 
     if (axl_file_buf_size != old_axl_file_buf_size + 1) {

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -1,5 +1,7 @@
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "axl.h"
 #include "axl_internal.h"
 
@@ -62,6 +64,7 @@ main(void) {
         return EXIT_FAILURE;
     }
 
+    /* check that all expected global variables were set */
     if (axl_file_buf_size != old_axl_file_buf_size + 1) {
         printf("AXL_Config() failed to set %s: %lu != %lu\n",
                AXL_KEY_CONFIG_FILE_BUF_SIZE, (long unsigned)axl_file_buf_size,
@@ -88,6 +91,125 @@ main(void) {
                !old_axl_copy_metadata);
         return EXIT_FAILURE;
     }
+
+    /* check that querying works (very similar to setter in library) */
+    static const char* known_options[] = {
+        AXL_KEY_CONFIG_FILE_BUF_SIZE,
+        AXL_KEY_CONFIG_DEBUG,
+        AXL_KEY_CONFIG_MKDIR,
+        AXL_KEY_CONFIG_COPY_METADATA,
+        NULL
+    };
+
+    size_t new_axl_file_buf_size;
+    int new_axl_debug, new_axl_make_directories, new_axl_copy_metadata;
+
+    kvtree *axl_configured_values = AXL_Config(NULL);
+    if (axl_configured_values == NULL) {
+        printf("AXL_Config() failed to get config\n");
+        return EXIT_FAILURE;
+    }
+
+    unsigned long ul;
+    if (kvtree_util_get_bytecount(axl_configured_values,
+      AXL_KEY_CONFIG_FILE_BUF_SIZE, &ul) != KVTREE_SUCCESS)
+    {
+        printf("Could not get %s from AXL_Config\n",
+               AXL_KEY_CONFIG_FILE_BUF_SIZE);
+        return EXIT_FAILURE;
+    }
+    new_axl_file_buf_size = (size_t) ul;
+    if (new_axl_file_buf_size != ul) {
+        char* value;
+        kvtree_util_get_str(axl_configured_values, AXL_KEY_CONFIG_FILE_BUF_SIZE,
+                            &value);
+        printf("Value '%s' passed for %s exceeds int range\n",
+          value, AXL_KEY_CONFIG_FILE_BUF_SIZE
+        );
+        return EXIT_FAILURE;
+    }
+    if (new_axl_file_buf_size != old_axl_file_buf_size+1) {
+        printf("AXL_Config returned unexpected value %llu for %s. Expected %llu.\n",
+               (unsigned long long)new_axl_file_buf_size,
+               AXL_KEY_CONFIG_FILE_BUF_SIZE,
+               (unsigned long long)old_axl_file_buf_size+1);
+        return EXIT_FAILURE;
+    }
+    
+    if (kvtree_util_get_int(axl_configured_values, AXL_KEY_CONFIG_DEBUG,
+                            &new_axl_debug) != KVTREE_SUCCESS)
+    {
+        printf("Could not get %s from AXL_Config\n",
+               AXL_KEY_CONFIG_DEBUG);
+        return EXIT_FAILURE;
+    }
+    if (new_axl_debug != !old_axl_file_buf_size) {
+        printf("AXL_Config returned unexpected value %d for %s. Expected %d.\n",
+               new_axl_debug, AXL_KEY_CONFIG_DEBUG, !old_axl_debug);
+        return EXIT_FAILURE;
+    }
+
+    if (kvtree_util_get_int(axl_configured_values, AXL_KEY_CONFIG_MKDIR,
+                            &new_axl_make_directories) != KVTREE_SUCCESS)
+    {
+        printf("Could not get %s from AXL_Config\n",
+               AXL_KEY_CONFIG_MKDIR);
+        return EXIT_FAILURE;
+    }
+    if (new_axl_make_directories != !old_axl_make_directories) {
+        printf("AXL_Config returned unexpected value %d for %s. Expected %d.\n",
+               new_axl_make_directories, AXL_KEY_CONFIG_MKDIR,
+               !old_axl_make_directories);
+        return EXIT_FAILURE;
+    }
+
+    if (kvtree_util_get_int(axl_configured_values, AXL_KEY_CONFIG_COPY_METADATA,
+                            &new_axl_copy_metadata) != KVTREE_SUCCESS)
+    {
+        printf("Could not get %s from AXL_Config\n",
+               AXL_KEY_CONFIG_COPY_METADATA);
+        return EXIT_FAILURE;
+    }
+    if (new_axl_copy_metadata != !old_axl_copy_metadata) {
+        printf("AXL_Config returned unexpected value %d for %s. Expected %d.\n",
+               new_axl_copy_metadata, AXL_KEY_CONFIG_COPY_METADATA,
+               !old_axl_copy_metadata);
+        return EXIT_FAILURE;
+    }
+
+    /* report all unknown options (typos?) */
+    const kvtree_elem* elem;
+    for (elem = kvtree_elem_first(axl_configured_values);
+         elem != NULL;
+         elem = kvtree_elem_next(elem))
+    {
+        /* must be only one level deep, ie plain kev = value */
+        const kvtree* elem_hash = kvtree_elem_hash(elem);
+        assert(kvtree_size(elem_hash) == 1);
+
+        const kvtree* kvtree_first_elem_hash =
+          kvtree_elem_hash(kvtree_elem_first(elem_hash));
+        assert(kvtree_size(kvtree_first_elem_hash) == 0);
+
+        /* check against known options */
+        const char** opt;
+        int found = 0;
+        for (opt = known_options; *opt != NULL; opt++) {
+            if (strcmp(*opt, kvtree_elem_key(elem)) == 0) {
+                found = 1;
+                break;
+            }
+        }
+        if (! found) {
+            printf("Unknown configuration parameter '%s' with value '%s'\n",
+              kvtree_elem_key(elem),
+              kvtree_elem_key(kvtree_elem_first(kvtree_elem_hash(elem)))
+            );
+            return EXIT_FAILURE;
+        }
+    }
+
+    kvtree_delete(&axl_configured_values);
 
     rc = AXL_Finalize();
     if (rc != AXL_SUCCESS) {

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -20,7 +20,7 @@ main(void) {
     rc = AXL_Init(state_file);
     if (rc != AXL_SUCCESS) {
         printf("AXL_Init() failed (error %d)\n", rc);
-        return rc;
+        return EXIT_FAILURE;
     }
 
     /* check AXL configuration settings */
@@ -29,25 +29,25 @@ main(void) {
                                    old_axl_file_buf_size + 1);
     if (rc != KVTREE_SUCCESS) {
         printf("kvtree_util_set_bytecount failed (error %d)\n", rc);
-        return rc;
+        return EXIT_FAILURE;
     }
     rc = kvtree_util_set_int(axl_config_values, AXL_KEY_CONFIG_DEBUG,
                              !old_axl_debug);
     if (rc != KVTREE_SUCCESS) {
         printf("kvtree_util_set_int failed (error %d)\n", rc);
-        return rc;
+        return EXIT_FAILURE;
     }
     rc = kvtree_util_set_int(axl_config_values, AXL_KEY_CONFIG_MKDIR,
                              !old_axl_make_directories);
     if (rc != KVTREE_SUCCESS) {
         printf("kvtree_util_set_int failed (error %d)\n", rc);
-        return rc;
+        return EXIT_FAILURE;
     }
     rc = kvtree_util_set_int(axl_config_values, AXL_KEY_CONFIG_COPY_METADATA,
                              !old_axl_copy_metadata);
     if (rc != KVTREE_SUCCESS) {
         printf("kvtree_util_set_int failed (error %d)\n", rc);
-        return rc;
+        return EXIT_FAILURE;
     }
 
     printf("Configuring AXL...\n");
@@ -92,8 +92,8 @@ main(void) {
     rc = AXL_Finalize();
     if (rc != AXL_SUCCESS) {
         printf("AXL_Finalize() failed (error %d)\n", rc);
-        return rc;
+        return EXIT_FAILURE;
     }
 
-    return AXL_SUCCESS;
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This pull request implements code to actually return values on `AXL_Config(NULL)`. Please take a look if this is sane and I will implement the same logic in the other components.

Things to note:

* there are some parameters that are accepted by `AXL_Config` to set but are ignored (documented but not used), these will not show up in the return `kvtree`

* the returned kvtree must be freed

* `test_config` now also checks the query interface