### PR TITLE
Add AXL_XFER_STATE_FILE xfer type

### DIFF
--- a/src/axl.h
+++ b/src/axl.h
@@ -49,6 +49,7 @@ typedef enum {
                              * to AXL_XFER_DEFAULT.
                              */
     AXL_XFER_PTHREAD,      /* parallel copy using pthreads */
+    AXL_XFER_STATE_FILE,    /* Use the xfer type specified in the state_file. */
 } axl_xfer_t;
 
 #define ARG0(dummy, a0, ...) a0

--- a/test/axl_cp.c
+++ b/test/axl_cp.c
@@ -36,6 +36,7 @@ axl_xfer_str_to_xfer(const char *xfer_str)
             {"bbapi", AXL_XFER_ASYNC_BBAPI},
             {"cppr", AXL_XFER_ASYNC_CPPR},
             {"pthread", AXL_XFER_PTHREAD},
+            {"state_file", AXL_XFER_STATE_FILE},
             {NULL, AXL_XFER_NULL},  /* must always be last element in array */
     };
     int i;
@@ -53,16 +54,16 @@ axl_xfer_str_to_xfer(const char *xfer_str)
 static void
 usage(void)
 {
-    printf("Usage: axl_cp [-apU] [-r|-R] [-S state_file] [-X xfer_type] SOURCE DEST\n");
-    printf("       axl_cp [-apU] [-r|-R] [-S state_file] [-X xfer_type] SOURCE... DIRECTORY\n");
+    printf("Usage: axl_cp [-ap] [-r|-R] [-S state_file [-U]] [-X xfer_type] SOURCE DEST\n");
+    printf("       axl_cp [-ap] [-r|-R] [-S state_file [-U]] [-X xfer_type] SOURCE... DIRECTORY\n");
     printf("\n");
     printf("-a:             Archive mode.  Preserve permissions + times + recursive.  Implies -pr\n");
     printf("-p:             Preserve permissions + times.\n");
     printf("-r|-R:          Copy directories recursively\n");
+    printf("-S state_file:  Reload state from state_file\n");
     printf("-U:             Resume copies to existing destination files if they exist\n");
-    printf("-X xfer_type:   AXL transfer type:  default native pthread sync dw bbapi cppr\n");
+    printf("-X xfer_type:   AXL transfer type: default native pthread sync dw bbapi cppr state_file.\n");
     printf("\n");
-
 }
 
 void sig_func(int signum)

--- a/test/test_axl.sh
+++ b/test/test_axl.sh
@@ -14,7 +14,7 @@ echo "
    -n num_files:    Number of files to create (default 50)
    -p bytes:        Pause the transfer after $bytes bytes
    -U:              After starting the transfer, kill -9 it, and resume it
-   xfer_type:       sync|pthread|bbapi|dw (defaults to sync if none specified)
+   xfer_type:       sync|pthread|bbapi|dw|state_file (defaults to sync if none specified)
 "
 }
 
@@ -146,8 +146,9 @@ function run_test
 	unset AXL_DEBUG_PAUSE_AFTER
 
 	if [ "$resume" == "1" ] ; then
-		# Resume our old transfer
-		./axl_cp -S /var/tmp/state_file -U -X $xfer -r $src/* $dest
+		# Resume our old transfer.  '-X state_file' tells axl_cp to use the
+		# transfer type we used previously in our state_file.
+		./axl_cp -S /var/tmp/state_file -U -X state_file -r $src/* $dest
 	fi
 	rc=$?
 	if [ "$rc" != "0" ] ; then


### PR DESCRIPTION
Add `AXL_XFER_STATE_FILE` transfer type.  This type is used to tell AXL that you want to use the transfer type specified in the
state_file.  This is useful if you're trying to resume a transfer from a previous state_file, since it saves you from having to
remember the old transfer type you used.