### PR TITLE
AXL: protect AXL's transfer file lists in multi-threading transfers

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -62,6 +62,11 @@ DEBUG           |    Boolean |       0 |  No | Set to 1 to have AXL print debug 
 MKDIR           |    Boolean |       1 | Yes | Specifies whether the destination file system supports the creation of directories (1) or not (0).
 COPY\_METADATA  |    Boolean |       0 | Yes | Whether file metadata like timestamp and permission bits should also be copied.
 
+Thread safety: setting the DEBUG or any per-transfer configuration value after
+the transfer has been dispatched entails a race contion between the main thread
+and the worker threads. Changing configuration options after a transfer has
+been dispatched is not supported.
+
 # Transferring files
 Regardless of the transfer type, the basic control flow of a transfer is always:
 1. AXL\_Create - allocate a new transfer object, providing its type and a name

--- a/src/axl.h
+++ b/src/axl.h
@@ -72,6 +72,9 @@ int AXL_Finalize (void);
  */
 int AXL_Create (axl_xfer_t xtype, const char* name, const char* state_file);
 
+/* needs to be above doxygen comment to get association right */
+typedef struct kvtree_struct kvtree;
+
 /**
  * Get/set AXL configuration values.
  *
@@ -80,11 +83,15 @@ int AXL_Create (axl_xfer_t xtype, const char* name, const char* state_file);
  *              then return a kvtree with all the configuration values (globals
  *              and all per-ID trees).
  *
+ * Thread safety: setting the DEBUG or any per-transfer configuration value
+ * after the transfer has been dispatched entails a race contion between the
+ * main thread and the worker threads. Changing configuration options after a
+ * transfer has been dispatched is not supported.
+ *
  * Return value: If config != NULL, then return config on success.  If
  *                      config=NULL (you're querying the config) then return
  *                      a new kvtree on success.  Return NULL on any failures.
  */
-typedef struct kvtree_struct kvtree;
 kvtree* AXL_Config(
   const kvtree* config        /** [IN] - kvtree of options */
 );

--- a/src/axl_internal.h
+++ b/src/axl_internal.h
@@ -14,13 +14,19 @@
 #define AXL_SUCCESS (0)
 #define AXL_FAILURE (-1)
 
+/* unless otherwise indicated all global variables defined in this file must
+ * only be accessed by the main thread */
+
 /*
  * A list of pointers to kvtrees, indexed by AXL ID.
  */
 extern kvtree** axl_kvtrees;
 
 /* current debug level for AXL library,
- * set in AXL_Init used in axl_dbg */
+ * set in AXL_Init and AXL_Config used in axl_dbg.
+ * There can be a race condition between the main thread setting this in
+ * AXL_Config and worker threads using it. Users are advised to be careful
+ * using debug options. */
 extern int axl_debug;
 
 /* flag to track whether file metadata should also be copied,


### PR DESCRIPTION
This is a continuation / transfer of https://github.com/rhaas80/AXL/pull/1 please see there for some comments.

Implementation notes:

* this assumes that AXL itself is not being called from a multi-threaded code, something already (tacitly) assumed by the way the state file is handled but not explicitly spelled out
* calling `AXL_Config` on a transfer that has already been dispatch is a race condition (since there is no lock on the individual `file_list` kvtrees) and not supported
* calling `AXL_Config` for the DEBUG settings is race condition (since `axl_debug` is not protected but is accessed from within the worker threads) while there are already dispatched transfers and will not be fixed