### PR TITLE
drop -Werror from default build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,7 @@ OPTION(AXL_LINK_STATIC "Default to static linking? (Needed for Cray)" OFF)
 SET(AXL_ASYNC_API "NONE" CACHE STRING "Vendor-specific asynchronous file transfer (CRAY_DW INTEL_CPPR IBM_BBAPI NONE)")
 SET_PROPERTY(CACHE AXL_ASYNC_API PROPERTY STRINGS NONE CRAY_DW INTEL_CPPR IBM_BBAPI)
 
-
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 
 # Find Packages & Files
 


### PR DESCRIPTION
One of our users tripped on a ``-Werror`` message.

```
axl_sync.c:39:13 error: variable 'success' set but not used [-Werror=unused-bug-set-variable]
  int success;
```

This PR disables those to make life easier for end users building with newer compilers that may be more strict.

We should use these flags in our travis/testing/development builds, but let's otherwise make life easier for our end users.