### PR TITLE
drop macro mangling for axl interface

### DIFF
--- a/src/axl.c
+++ b/src/axl.c
@@ -239,9 +239,8 @@ API Functions
 ========================================
 */
 
-/* Read configuration from non-AXL-specific file
-  Also, start up vendor specific services */
-int __AXL_Init (const char* state_file)
+/* Initialize library and start up vendor specific services */
+int AXL_Init (void)
 {
     int rc = AXL_SUCCESS;
 
@@ -268,11 +267,6 @@ int __AXL_Init (const char* state_file)
     val = getenv("AXL_MKDIR");
     if (val != NULL) {
         axl_make_directories = atoi(val);
-    }
-
-    if (state_file != NULL) {
-        printf("WARNING: Passing a state_file to AXL_Init() is deprecated." \
-               "Pass it to AXL_Create(id, type, state_file) instead.\n");
     }
 
 #ifdef HAVE_BBAPI
@@ -544,7 +538,7 @@ kvtree* AXL_Config(const kvtree* config)
  * Type specifies a particular method to use
  * Name is a user/application provided string
  * Returns an ID to the transfer handle */
-int __AXL_Create(axl_xfer_t xtype, const char* name, const char* state_file)
+int AXL_Create(axl_xfer_t xtype, const char* name, const char* state_file)
 {
     /* Generate next unique ID */
     int id = axl_alloc_id(state_file);

--- a/src/axl.h
+++ b/src/axl.h
@@ -52,19 +52,10 @@ typedef enum {
     AXL_XFER_STATE_FILE,    /* Use the xfer type specified in the state_file. */
 } axl_xfer_t;
 
-#define ARG0(dummy, a0, ...) a0
-#define GET_ARG0(...) ARG0(dummy, ## __VA_ARGS__, 0)
-
 /*
  * int AXL_Init(void) - Initialize the library.
- *
- * NOTE: AXL_Init() used to take in a state_file argument, but this has
- * since been removed. We do some macro mangling to make sure both state_file
- * version and the no-arg version both work, but the state_file version is
- * deprecated and should not be used.
  */
-#define AXL_Init(...) __AXL_Init(GET_ARG0(__VA_ARGS__))
-int __AXL_Init (const char* state_file);
+int AXL_Init (void);
 
 /** Shutdown any vendor services */
 int AXL_Finalize (void);
@@ -78,16 +69,8 @@ int AXL_Finalize (void);
  *              resume transfers after a crash.
  *
  * Returns an AXL ID, or negative number on error.
- *
- * NOTE: AXL_Create() used to only take in type and name.  The state_file arg
- * was added later.  We do some macro mangling to make sure both 2-arg and
- * 3-arg versions of AXL_Create() work, but the 2-arg version is deprecated
- * and should not be used.  If you're loading from an existing state_file, then
- * type must be the same as the type in state_file.
  */
-#define AXL_Create(type, name, ...) \
-        __AXL_Create(type, name, GET_ARG0(__VA_ARGS__))
-int __AXL_Create (axl_xfer_t xtype, const char* name, const char* state_file);
+int AXL_Create (axl_xfer_t xtype, const char* name, const char* state_file);
 
 /**
  * Get/set AXL configuration values.

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -369,7 +369,7 @@ main(void) {
     old_axl_copy_metadata = axl_copy_metadata;
 
     /* must pick up "old" defaults */
-    int id1 = AXL_Create(AXL_XFER_DEFAULT, __FILE__);
+    int id1 = AXL_Create(AXL_XFER_DEFAULT, __FILE__, NULL);
     if (id1 < 0) {
         printf("AXL_Create() failed (error %d)\n", id1);
         exit(EXIT_FAILURE);
@@ -379,7 +379,7 @@ main(void) {
     get_global_options();
 
     /* must pick up "new" defaults */
-    int id2 = AXL_Create(AXL_XFER_DEFAULT, __FILE__);
+    int id2 = AXL_Create(AXL_XFER_DEFAULT, __FILE__, NULL);
     if (id2 < 0) {
         printf("AXL_Create() failed (error %d)\n", id2);
         exit(EXIT_FAILURE);


### PR DESCRIPTION
Though this trick allows users of the old interface to compile, it still leaves them broken since it does not function according to the old semantics.  Let's bite the bullet and make users upgrade to the new interface.