### PR TITLE
Record metadata to state_file by default

### DIFF
--- a/src/axl_internal.h
+++ b/src/axl_internal.h
@@ -116,7 +116,6 @@ int axl_file_copy(
     const char* src_file,
     const char* dst_file,
     unsigned long buf_size,
-    int copy_metadata,
     int resume
 );
 
@@ -171,5 +170,8 @@ int axl_meta_encode(const char* file, kvtree* meta);
 
 /* copy metadata settings recorded in provided kvtree to specified file */
 int axl_meta_apply(const char* file, const kvtree* meta);
+
+/* Check if a file is the size we expect it to be */
+int axl_check_file_size(const char* file, const kvtree* meta);
 
 #endif /* AXL_INTERNAL_H */

--- a/src/axl_pthread.c
+++ b/src/axl_pthread.c
@@ -217,13 +217,8 @@ static void* axl_pthread_func(void* arg)
                                             AXL_KEY_CONFIG_FILE_BUF_SIZE, &file_buf_size);
         assert(success == KVTREE_SUCCESS);
 
-        int copy_metadata;
-        success = kvtree_util_get_int(file_list, AXL_KEY_CONFIG_COPY_METADATA,
-                                      &copy_metadata);
-        assert(success == KVTREE_SUCCESS);
-
         /* Copy the file from soruce to destination */
-        int rc = axl_file_copy(src, dst, file_buf_size, copy_metadata, pdata->resume);
+        int rc = axl_file_copy(src, dst, file_buf_size, pdata->resume);
         AXL_DBG(2, "%s: Read and copied %s to %s, rc %d",
             __func__, src, dst, rc);
 

--- a/src/axl_sync.c
+++ b/src/axl_sync.c
@@ -44,16 +44,10 @@ int __axl_sync_start (int id, int resume)
                                             AXL_KEY_CONFIG_FILE_BUF_SIZE, &file_buf_size);
         assert(success == KVTREE_SUCCESS);
 
-        int copy_metadata;
-        success = kvtree_util_get_int(file_list, AXL_KEY_CONFIG_COPY_METADATA,
-                                      &copy_metadata);
-        assert(success == KVTREE_SUCCESS);
-
         /* Copy the file */
         char* destination;
         kvtree_util_get_str(elem_hash, AXL_KEY_FILE_DEST, &destination);
-        int tmp_rc = axl_file_copy(source, destination, file_buf_size,
-                                   copy_metadata, resume);
+        int tmp_rc = axl_file_copy(source, destination, file_buf_size, resume);
         if (tmp_rc == AXL_SUCCESS) {
             kvtree_util_set_int(elem_hash, AXL_KEY_FILE_STATUS, AXL_STATUS_DEST);
         } else {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,9 +21,11 @@ TARGET_LINK_LIBRARIES(test_config axl)
 ################
 
 CONFIGURE_FILE(test_axl.sh ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
+CONFIGURE_FILE(test_axl_metadata.sh ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
 
 ADD_TEST(sync_test test_axl.sh sync)
 ADD_TEST(pthreads_test test_axl.sh pthread)
+ADD_TEST(metadata_test test_axl_metadata.sh)
 IF(BBAPI_FOUND)
     ADD_TEST(bbapi_test test_axl.sh bbapi)
 

--- a/test/test_axl_metadata.sh
+++ b/test/test_axl_metadata.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# AXL metadata copy test.
+#
+# Make two files, set some metadata on them (size, times, permission), copy
+# the file, and verify the metadata is correct.
+
+src=$(mktemp -d)
+dest=$(mktemp -d)
+
+trap ctrl_c INT
+
+function cleanup
+{
+	rm -fr "$src" "$dest"
+}
+
+function ctrl_c() {
+	cleanup
+}
+
+# Create two files and set some metadata
+dd if=/dev/zero of=$src/file1 bs=1 count=1
+dd if=/dev/zero of=$src/file2 bs=1 count=5
+
+chmod 444 $src/file1
+chmod 777 $src/file2
+touch -d "1 hour ago" $src/file1
+touch -d "1 day ago" $src/file2
+
+# Do a simple transfer and verify the result
+./axl_cp -a $src/* $dest
+src_ls="$(ls -l $src)"
+dest_ls="$(ls -l $dest)"
+
+if [ "$src_ls" != "$dest_ls" ] ; then
+	echo "Error: source and dest metadata doesn't match:"
+	echo "$src_ls"
+	echo "-----------------------------------"
+	echo "$dest_ls"
+	cleanup
+	exit 1
+fi
+
+rm -f $dest/*
+
+# Now do another transfer without copying metadata. The permissions
+# should be different between the source and destination.
+./axl_cp $src/* $dest
+src_ls="$(ls -l $src)"
+dest_ls="$(ls -l $dest)"
+if [ "$src_ls" == "$dest_ls" ] ; then
+	echo "Error: source and dest metadata matches, but shouldn't:"
+	echo "$src_ls"
+	echo "-----------------------------------"
+	echo "$dest_ls"
+	cleanup
+	exit 1
+fi
+cleanup


### PR DESCRIPTION
No matter what, we need to do a stat call on each file to get the file's size.  This stat call also gives us all the file's metadata (permissions, UID, GID, creation times) "for free".  This patch encodes the size and all metadata by default into the state_file.  This is needed for finalizing transfers after a burst buffer transfer has finished, and the source files are no longer available.

This change does not affect `AXL_COPY_METADATA`.  It must still be set in order to apply the metadata to the file after it has been transferred.  This patch does however, do an additional file size check at the end of a transfer, at a cost of a stat per file.