### PR TITLE
add cmake option to toggle pthreads

### DIFF
--- a/src/axl.c
+++ b/src/axl.c
@@ -32,7 +32,7 @@
 
 #ifdef HAVE_PTHREADS
 #include "axl_pthread.h"
-#endif
+#endif /* HAVE_PTHREAD */
 
 #ifdef HAVE_BBAPI
 #include "axl_async_bbapi.h"


### PR DESCRIPTION
This defines a new ``-DENABLE_PTHREADS=[ON/OFF]`` option that one can use to toggle pthreads.  It defaults to ON, so this lets one disable building the pthread support.  That might be helpful for someone running on a system where pthreads is not installed, or more likely, one does not want to add a ``-lpthread`` to their link because they otherwise don't have a pthreads dependency.