### PR TITLE
Add MPI option to AXL

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,6 @@
+#
+# TODO: Add MPI for CI
+#
 slurm-job:
   tags:
     - quartz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 INCLUDE(GNUInstallDirs)
 
 # Configuration Options
+OPTION(MPI "Enable MPI operations for AXL" OFF)
+MESSAGE(STATUS "MPI: ${MPI}")
+
 OPTION(BUILD_SHARED_LIBS "Whether to build shared libraries" ON)
 MESSAGE(STATUS "BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 
@@ -44,6 +47,21 @@ SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 # Find Packages & Files
 
 LIST(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
+## MPI
+IF(MPI)
+    INCLUDE(SetupMPI)
+    IF(MPI_C_FOUND)
+        INCLUDE_DIRECTORIES(${MPI_C_INCLUDE_PATH})
+        LIST(APPEND AXL_EXTERNAL_LIBS ${MPI_C_LIBRARIES})
+    ELSE(MPI_C_FOUND)
+        MESSAGE(FATAL_ERROR
+            "Could not find MPI! "
+            "Either add an MPI compiler to your path "
+            "or force CMake to build using the correct compiler (`export CC=mpicc`). "
+            "To disable MPI, set -DMPI=OFF")
+    ENDIF(MPI_C_FOUND)
+ENDIF(MPI)
 
 ## KVTREE
 FIND_PACKAGE(KVTREE REQUIRED)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Some useful CMake command line options:
 
 - `-DCMAKE_INSTALL_PREFIX=[path]`: Place to install the AXL library
 - `-DCMAKE_BUILD_TYPE=[Debug/Release]`: Build with debugging or optimizations
-- `-DMPI`: Build with support for MPI movement of kvtree objects
+- `-DMPI`: Build support for MPI collective interface
 
 For building with IBM BB API (optional):
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Some useful CMake command line options:
 
 - `-DCMAKE_INSTALL_PREFIX=[path]`: Place to install the AXL library
 - `-DCMAKE_BUILD_TYPE=[Debug/Release]`: Build with debugging or optimizations
+- `-DMPI`: Build with support for MPI movement of kvtree objects
 
 For building with IBM BB API (optional):
 
@@ -39,6 +40,7 @@ For building with IBM BB API (optional):
 - C
 - CMake, Version 2.8+
 - [KVTree](https://github.com/LLNL/KVTree)
+- MPI (optional)
 
 ## Authors
 

--- a/cmake/SetupMPI.cmake
+++ b/cmake/SetupMPI.cmake
@@ -1,0 +1,77 @@
+###############################################################################
+# Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+#
+# Produced at the Lawrence Livermore National Laboratory
+#
+# LLNL-CODE-725085
+#
+# All rights reserved.
+#
+# This file is part of BLT.
+#
+# For additional details, please also read BLT/LICENSE.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the disclaimer below.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the disclaimer (as noted below) in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of the LLNS/LLNL nor the names of its contributors may
+#   be used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+# LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+###############################################################################
+
+################################
+# MPI
+################################
+
+find_package(MPI)
+message(STATUS "MPI C Compile Flags:  ${MPI_C_COMPILE_FLAGS}")
+message(STATUS "MPI C Include Path:   ${MPI_C_INCLUDE_PATH}")
+message(STATUS "MPI C Link Flags:     ${MPI_C_LINK_FLAGS}")
+message(STATUS "MPI C Libraries:      ${MPI_C_LIBRARIES}")
+
+message(STATUS "MPI CXX Compile Flags: ${MPI_CXX_COMPILE_FLAGS}")
+message(STATUS "MPI CXX Include Path:  ${MPI_CXX_INCLUDE_PATH}")
+message(STATUS "MPI CXX Link Flags:    ${MPI_CXX_LINK_FLAGS}")
+message(STATUS "MPI CXX Libraries:     ${MPI_CXX_LIBRARIES}")
+
+message(STATUS "MPI Executable:       ${MPIEXEC}")
+message(STATUS "MPI Num Proc Flag:    ${MPIEXEC_NUMPROC_FLAG}")
+
+
+if (ENABLE_FORTRAN)
+    # Determine if we should use fortran mpif.h header or fortran mpi module
+    find_path(mpif_path
+        NAMES "mpif.h"
+        PATHS ${MPI_Fortran_INCLUDE_PATH}
+        NO_DEFAULT_PATH
+        )
+
+    if(mpif_path)
+        set(MPI_Fortran_USE_MPIF ON CACHE PATH "")
+        message(STATUS "Using MPI Fortran header: mpif.h")
+    else()
+        set(MPI_Fortran_USE_MPIF OFF CACHE PATH "")
+        message(STATUS "Using MPI Fortran module: mpi.mod")
+    endif()
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,9 +6,12 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_BINARY_DIR})
 ###########
 
 # Install header files
-LIST(APPEND libaxl_install_headers
-    axl.h
-)
+LIST(APPEND libaxl_install_headers axl.h)
+
+IF(MPI_FOUND)
+    LIST(APPEND libaxl_install_headers axl_mpi.h)
+ENDIF(MPI_FOUND)
+
 INSTALL(FILES ${libaxl_install_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 LIST(APPEND libaxl_srcs
@@ -18,6 +21,10 @@ LIST(APPEND libaxl_srcs
     axl_io.c
     axl_util.c
 )
+
+IF(MPI_FOUND)
+    LIST(APPEND libaxl_srcs axl_mpi.c)
+ENDIF(MPI_FOUND)
 
 IF(HAVE_PTHREADS)
   LIST(APPEND libaxl_srcs axl_pthread.c)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,22 +22,19 @@ LIST(APPEND libaxl_srcs
     axl_util.c
 )
 
-IF(MPI_FOUND)
-    LIST(APPEND libaxl_srcs axl_mpi.c)
-ENDIF(MPI_FOUND)
-
 IF(HAVE_PTHREADS)
-  LIST(APPEND libaxl_srcs axl_pthread.c)
+    LIST(APPEND libaxl_srcs axl_pthread.c)
 ENDIF(HAVE_PTHREADS)
 
 IF(BBAPI_FOUND)
-  LIST(APPEND libaxl_srcs axl_async_bbapi.c)
+    LIST(APPEND libaxl_srcs axl_async_bbapi.c)
 ENDIF(BBAPI_FOUND)
 
 IF(HAVE_DATAWARP)
-  LIST(APPEND libaxl_srcs axl_async_datawarp.c)
+    LIST(APPEND libaxl_srcs axl_async_datawarp.c)
 ENDIF(HAVE_DATAWARP)
 
+# Default AXL library is withOUT MPI
 ADD_LIBRARY(axl_o OBJECT ${libaxl_srcs})
 
 IF(BUILD_SHARED_LIBS)
@@ -56,3 +53,29 @@ TARGET_LINK_LIBRARIES(axl-static ${AXL_EXTERNAL_LIBS})
 
 SET_TARGET_PROPERTIES(axl-static PROPERTIES OUTPUT_NAME axl CLEAN_DIRECT_OUTPUT 1)
 INSTALL(TARGETS axl-static DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+# AXL library with MPI
+LIST(APPEND libaxl_mpi_srcs ${libaxl_srcs})
+
+IF(MPI_FOUND)
+    LIST(APPEND libaxl_mpi_srcs axl_mpi.c)
+ENDIF(MPI_FOUND)
+
+ADD_LIBRARY(axl_mpi_o OBJECT ${libaxl_mpi_srcs})
+
+IF(BUILD_SHARED_LIBS)
+    ADD_LIBRARY(axl_mpi SHARED $<TARGET_OBJECTS:axl_mpi_o>)
+    TARGET_LINK_LIBRARIES(axl_mpi ${AXL_EXTERNAL_LIBS})
+    SET_TARGET_PROPERTIES(axl_mpi PROPERTIES OUTPUT_NAME axl_mpi CLEAN_DIRECT_OUTPUT 1)
+    INSTALL(TARGETS axl_mpi DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ENDIF()
+
+ADD_LIBRARY(axl_mpi-static STATIC $<TARGET_OBJECTS:axl_mpi_o>)
+IF(AXL_LINK_STATIC)
+    SET_TARGET_PROPERTIES(axl_mpi-static PROPERTIES LINK_SEARCH_START_STATIC 1)
+    SET_TARGET_PROPERTIES(axl_mpi-static PROPERTIES LINK_SEARCH_END_STATIC 1)
+ENDIF(AXL_LINK_STATIC)
+TARGET_LINK_LIBRARIES(axl_mpi-static ${AXL_EXTERNAL_LIBS})
+
+SET_TARGET_PROPERTIES(axl_mpi-static PROPERTIES OUTPUT_NAME axl_mpi CLEAN_DIRECT_OUTPUT 1)
+INSTALL(TARGETS axl_mpi-static DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/axl_mpi.c
+++ b/src/axl_mpi.c
@@ -1,0 +1,300 @@
+#include <stdlib.h>
+#include <string.h>
+#include <libgen.h>
+
+#include "axl.h"
+#include "axl_mpi.h"
+
+#include "kvtree.h"
+#include "kvtree_util.h"
+
+#include "config.h"
+
+#include "mpi.h"
+
+#define AXL_FAILURE (1)
+
+static int axl_alltrue(int valid, MPI_Comm comm)
+{
+    int all_valid;
+    MPI_Allreduce(&valid, &all_valid, 1, MPI_INT, MPI_LAND, comm);
+    return all_valid;
+}
+
+/* caller really passes in a void**, but we define it as just void* to avoid printing
+ * a bunch of warnings */
+void axl_free2(void* p) {
+    /* verify that we got a valid pointer to a pointer */
+    if (p != NULL) {
+        /* free memory if there is any */
+        void* ptr = *(void**)p;
+        if (ptr != NULL) {
+            free(ptr);
+        }
+
+        /* set caller's pointer to NULL */
+        *(void**)p = NULL;
+    }
+}
+
+int AXL_Init_comm (
+    MPI_Comm comm)    /**< [IN]  - communicator used for coordination and flow control */
+{
+    /* initialize AXL */
+    int rc = AXL_Init();
+
+    /* return same value on all ranks */
+    if (! axl_alltrue(rc == AXL_SUCCESS, comm)) {
+        /* someone failed, so everyone fails */
+
+        /* if our call to init succeeded,
+         * cal finalize to clean up */
+        if (rc == AXL_SUCCESS) {
+            AXL_Finalize();
+        }
+
+        /* return failure to everyone */
+        return AXL_FAILURE;
+    }
+
+    return rc;
+}
+
+int AXL_Finalize_comm (
+    MPI_Comm comm)    /**< [IN]  - communicator used for coordination and flow control */
+{
+    int rc = AXL_SUCCESS;
+
+    int axl_rc = AXL_Finalize();
+    if (axl_rc != AXL_SUCCESS) {
+        rc = axl_rc;
+    }
+
+    /* return same value on all ranks */
+    if (! axl_alltrue(rc == AXL_SUCCESS, comm)) {
+        /* someone failed, so everyone fails */
+
+        /* return failure to everyone */
+        rc = AXL_FAILURE;
+    }
+
+    return rc;
+}
+
+int AXL_Create_comm (
+    axl_xfer_t type,  /**< [IN]  - AXL transfer type (AXL_XFER_SYNC, AXL_XFER_PTHREAD, etc) */
+    const char* name, 
+    const char* file,
+    MPI_Comm comm)    /**< [IN]  - communicator used for coordination and flow control */
+{
+    int id = AXL_Create(type, name, file);
+
+    /* NOTE: We do not force id to be the same on all ranks.
+     * It may be useful to do that, but then we need collective
+     * allocation. */
+
+    /* return same value on all ranks */
+    if (! axl_alltrue(id != -1, comm)) {
+      /* someone failed, so everyone fails */
+
+      /* if this process succeeded in create,
+       * free its handle to clean up */
+      if (id != -1) {
+          AXL_Free(id);
+      }
+
+      /* return -1 to everyone */
+      id = -1;
+    }
+
+    return id;
+}
+
+int AXL_Add_comm (
+  int id,           /**< [IN]  - transfer hander ID returned from AXL_Create */
+  int num,          /**< [IN]  - number of files in src and dst file lists */
+  const char** src, /**< [IN]  - list of source paths of length num */
+  const char** dst, /**< [IN]  - list of destination paths of length num */
+  MPI_Comm comm)    /**< [IN]  - communicator used for coordination and flow control */
+{
+    /* assume we'll succeed */
+    int rc = AXL_SUCCESS;
+
+    /* add files to transfer list */
+    int i;
+    for (i = 0; i < num; i++) {
+      const char* src_file  = src[i];
+      const char* dest_file = dst[i];
+      if (AXL_Add(id, src_file, dest_file) != AXL_SUCCESS) {
+        /* remember that we failed to add a file */
+        rc = AXL_FAILURE;
+      }
+    }
+
+    /* return same value on all ranks */
+    if (! axl_alltrue(rc == AXL_SUCCESS, comm)) {
+        /* someone failed, so everyone fails */
+        rc = AXL_FAILURE;
+    }
+
+    return rc;
+}
+
+int AXL_Dispatch_comm (
+    int id,        /**< [IN]  - transfer hander ID returned from AXL_Create */
+    MPI_Comm comm) /**< [IN]  - communicator used for coordination and flow control */
+{
+#if 0
+    /* lookup transfer info for the given id */
+    kvtree* file_list = NULL;
+    axl_xfer_t xtype = AXL_XFER_NULL;
+    axl_xfer_state_t xstate = AXL_XFER_STATE_NULL;
+    if (axl_get_info(id, &file_list, &xtype, &xstate) != AXL_SUCCESS) {
+        AXL_ERR("Could not find transfer info for UID %d", id);
+        return AXL_FAILURE;
+    }
+
+    /* check that handle is in correct state to dispatch */
+    if (xstate != AXL_XFER_STATE_CREATED) {
+        AXL_ERR("Invalid state to dispatch UID %d", id);
+        return AXL_FAILURE;
+    }
+    kvtree_util_set_int(file_list, AXL_KEY_STATE, (int)AXL_XFER_STATE_DISPATCHED);
+#endif
+
+#if 0
+    /* create destination directories for each file */
+    if (axl_make_directories) {
+        /* count number of files we have */
+        kvtree* file_list = kvtree_get_kv_int(axl_file_lists, AXL_KEY_HANDLE_UID, id);
+        kvtree* files_hash = kvtree_get(file_list, AXL_KEY_FILES);
+        int num_files = kvtree_size(files_hash);
+
+        /* allocate pointer for each one */
+        const char** files = (const char**) AXL_MALLOC(num_files * sizeof(char*));
+
+        /* set pointer to each file */
+        int i;
+        char* dest;
+        kvtree_elem* elem;
+        while ((elem = axl_get_next_path(id, elem, NULL, &dest))) {
+            files[i] = dest;
+            i++;
+        }
+
+        /* create directories */
+        axl_create_dirs(num_files, files, comm);
+
+        /* free list of files */
+        axl_free2(&files);
+    }
+
+    /* TODO: this is hacky */
+    /* delegate remaining work to regular dispatch,
+     * but disable mkdir since we already did that */
+    int make_dir = axl_make_directories;
+    axl_make_directories = 0;
+    int rc = AXL_Dispatch(id);
+    axl_make_directories = make_dir;
+#endif
+    /* delegate remaining work to regular dispatch */
+    int rc = AXL_Dispatch(id);
+
+    /* return same value on all ranks */
+    if (! axl_alltrue(rc == AXL_SUCCESS, comm)) {
+        /* someone failed, so everyone fails */
+
+        /* TODO: do we have another option than cancel/wait? */
+        /* If dispatch succeeded on this process, cancel and wait.
+         * This is ugly but necessary since the caller will free
+         * the handle when we return, since we're telling the caller
+         * that the collective dispatch failed.  The handle needs
+         * to be in a state that can be freed. */
+        if (rc == AXL_SUCCESS) {
+            AXL_Cancel(id);
+            AXL_Wait(id);
+
+            /* TODO: should we also delete files,
+             * since they may have already been transferred? */
+        }
+
+        /* return failure to everyone */
+        rc = AXL_FAILURE;
+    }
+
+    return rc;
+}
+
+int AXL_Test_comm (
+    int id,        /**< [IN]  - transfer hander ID returned from AXL_Create */
+    MPI_Comm comm) /**< [IN]  - communicator used for coordination and flow control */
+{
+    int rc = AXL_Test(id);
+
+    /* return same value on all ranks */
+    if (! axl_alltrue(rc == AXL_SUCCESS, comm)) {
+        /* someone failed, so everyone fails */
+        rc = AXL_FAILURE;
+    }
+
+    return rc;
+}
+
+int AXL_Wait_comm (
+    int id,        /**< [IN]  - transfer hander ID returned from AXL_Create */
+    MPI_Comm comm) /**< [IN]  - communicator used for coordination and flow control */
+{
+    int rc = AXL_Wait(id);
+
+    /* return same value on all ranks */
+    if (! axl_alltrue(rc == AXL_SUCCESS, comm)) {
+        /* someone failed, so everyone fails */
+        rc = AXL_FAILURE;
+    }
+
+    return rc;
+}
+
+int AXL_Cancel_comm (
+    int id,        /**< [IN]  - transfer hander ID returned from AXL_Create */
+    MPI_Comm comm) /**< [IN]  - communicator used for coordination and flow control */
+{
+    int rc = AXL_Cancel(id);
+
+    /* return same value on all ranks */
+    if (! axl_alltrue(rc == AXL_SUCCESS, comm)) {
+        /* someone failed, so everyone fails */
+        rc = AXL_FAILURE;
+    }
+
+    return rc;
+}
+
+int AXL_Free_comm (
+    int id,        /**< [IN]  - transfer hander ID returned from AXL_Create */
+    MPI_Comm comm) /**< [IN]  - communicator used for coordination and flow control */
+{
+    int rc = AXL_Free(id);
+
+    /* return same value on all ranks */
+    if (! axl_alltrue(rc == AXL_SUCCESS, comm)) {
+        /* someone failed, so everyone fails */
+        rc = AXL_FAILURE;
+    }
+
+    return rc;
+}
+
+int AXL_Stop_comm (
+    MPI_Comm comm) /**< [IN]  - communicator used for coordination and flow control */
+{
+    int rc = AXL_Stop();
+
+    /* return same value on all ranks */
+    if (! axl_alltrue(rc == AXL_SUCCESS, comm)) {
+        /* someone failed, so everyone fails */
+        rc = AXL_FAILURE;
+    }
+
+    return rc;
+}

--- a/src/axl_mpi.h
+++ b/src/axl_mpi.h
@@ -1,0 +1,82 @@
+#ifndef AXL_MPI_H
+#define AXL_MPI_H
+
+#include "axl.h"
+#include "mpi.h"
+
+/* enable C++ codes to include this header directly */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \defgroup axl AXL
+ *  \brief Asynchronous Transfer Library
+ *
+ * For MPI jobs in which multiple processes issue transfes simultaneously,
+ * communicators can be used to optimize file I/O operations.  This extends
+ * the AXL interface to work with a communicator.  One must provide the same
+ * group of processes and in the same order as used in the communicator to
+ * create the transfer handle. */
+
+/** \file axl_mpi.h
+ *  \ingroup axl
+ *  \brief asynchronous transfer library for MPI communicators */
+
+int AXL_Init_comm (
+  MPI_Comm comm     /**< [IN]  - communicator used for coordination and flow control */
+);
+
+int AXL_Finalize_comm (
+  MPI_Comm comm     /**< [IN]  - communicator used for coordination and flow control */
+);
+
+int AXL_Create_comm (
+  axl_xfer_t type,  /**< [IN]  - AXL transfer type (AXL_XFER_SYNC, AXL_XFER_PTHREAD, etc) */
+  const char* name, /**< [IN]  - user-defined name for transfer */
+  const char* file, /**< [IN]  - optional state file to persist transfer state */
+  MPI_Comm comm     /**< [IN]  - communicator used for coordination and flow control */
+);
+
+int AXL_Add_comm (
+  int id,           /**< [IN]  - transfer hander ID returned from AXL_Create */
+  int num,          /**< [IN]  - number of files in src and dst file lists */
+  const char** src, /**< [IN]  - list of source paths of length num */
+  const char** dst, /**< [IN]  - list of destination paths of length num */
+  MPI_Comm comm     /**< [IN]  - communicator used for coordination and flow control */
+);
+
+int AXL_Dispatch_comm (
+  int id,       /**< [IN]  - transfer hander ID returned from AXL_Create */
+  MPI_Comm comm /**< [IN]  - communicator used for coordination and flow control */
+);
+
+int AXL_Test_comm (
+  int id,       /**< [IN]  - transfer hander ID returned from AXL_Create */
+  MPI_Comm comm /**< [IN]  - communicator used for coordination and flow control */
+);
+
+int AXL_Wait_comm (
+  int id,       /**< [IN]  - transfer hander ID returned from AXL_Create */
+  MPI_Comm comm /**< [IN]  - communicator used for coordination and flow control */
+);
+
+int AXL_Cancel_comm (
+  int id,       /**< [IN]  - transfer hander ID returned from AXL_Create */
+  MPI_Comm comm /**< [IN]  - communicator used for coordination and flow control */
+);
+
+int AXL_Free_comm (
+  int id,       /**< [IN]  - transfer hander ID returned from AXL_Create */
+  MPI_Comm comm /**< [IN]  - communicator used for coordination and flow control */
+);
+
+int AXL_Stop_comm (
+  MPI_Comm comm /**< [IN]  - communicator used for coordination and flow control */
+);
+
+/* enable C++ codes to include this header directly */
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* AXL_MPI_H */


### PR DESCRIPTION
This is a refactoring step to migrate the MPI AXL wrapper
implementation out of SCR and in to AXL.  MPI will only be enabled
when AXL is compiled with -DMPI=ON (MPI=OFF by default).

There is no intended change in function with this refactoring.  The axl_mpi wrapper API functions that were previously in SCR have been moved to this library.

This relates to [#489](https://github.com/LLNL/scr/issues/489)
This also relates to the SCR PR here: https://github.com/LLNL/scr/pull/501
