### PR TITLE
extend matrix to build with and without shared libs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,8 +16,13 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         target: [Debug, Release]
         mpi: [seq, par]
-        shared: [true, false]
-        static: [true, false]
+        shared: [build-shared, build-static]
+        static: [link-shared, link-static]
+        exclude:
+          # don't try to link to the shared
+          # library when it's not built
+          - shared: build-static
+            static: link-shared
 
     name: ${{ matrix.os }}-${{ matrix.target }}-${{ matrix.mpi }}-${{ matrix.shared }}-${{ matrix.static }}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,14 +49,6 @@ jobs:
           mpi: ${{ matrix.mpi }}
           shared: ${{ matrix.shared }}
 
-      - name: build static
-        uses: ecp-veloc/github-actions/cmake-build-static@main
-        with:
-          component: axl
-          target: ${{ matrix.target }}
-          shared: ${{ matrix.shared }}
-          cmake_line: "-DMPI=${{ matrix.mpi == 'par' }}"
-
       - name: build only
         uses: ecp-veloc/github-actions/cmake-build-only@main
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,8 +16,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         target: [Debug, Release]
         mpi: [seq, par]
+        shared: [true, false]
+        static: [true, false]
 
-    name: ${{ matrix.os }}-${{ matrix.target }}-${{ matrix.mpi }}
+    name: ${{ matrix.os }}-${{ matrix.target }}-${{ matrix.mpi }}-${{ matrix.shared }}-${{ matrix.static }}
 
     runs-on: ${{ matrix.os }}
 
@@ -40,12 +42,14 @@ jobs:
         with:
           component: kvtree
           mpi: ${{ matrix.mpi }}
+          shared: ${{ matrix.shared }}
 
       - name: build static
         uses: ecp-veloc/github-actions/cmake-build-static@main
         with:
           component: axl
           target: ${{ matrix.target }}
+          shared: ${{ matrix.shared }}
           cmake_line: "-DMPI=${{ matrix.mpi == 'par' }}"
 
       - name: build only
@@ -53,4 +57,6 @@ jobs:
         with:
           component: axl
           target: ${{ matrix.target }}
+          shared: ${{ matrix.shared }}
+          static: ${{ matrix.static }}
           cmake_line: "-DMPI=${{ matrix.mpi == 'par' }}"


### PR DESCRIPTION
This uses a new ``shared`` setting to toggle shared lib builds of both AXL and its dependencies.  If the shared library is not built for AXL, then its ECP dependencies should not built their shared libs either.

Depends on: https://github.com/ECP-VeloC/github-actions/pull/1

The combo of ``-DBUILD_SHARED_LIBS=OFF`` and ``-DAXL_LINK_STATIC=OFF`` is not expected to work.  We can't link executables to the shared library when it is not built.  We exclude that combo from the matrix:

https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#excluding-matrix-configurations