### PR TITLE
cmake: install cmake find modules for bbapi and datawarp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,8 @@ WRITE_BASIC_PACKAGE_VERSION_FILE(${CMAKE_CURRENT_BINARY_DIR}/axlConfigVersion.cm
 
 # Install package config
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/axlConfig.cmake ${CMAKE_CURRENT_BINARY_DIR}/axlConfigVersion.cmake DESTINATION share/axl/cmake)
+INSTALL(FILES cmake/FindBBAPI.cmake    DESTINATION share/axl/cmake)
+INSTALL(FILES cmake/FindDataWarp.cmake DESTINATION share/axl/cmake)
 
 # Package
 SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Asynchronous Transfer Library")

--- a/cmake/axlConfig.cmake.in
+++ b/cmake/axlConfig.cmake.in
@@ -4,6 +4,13 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(kvtree REQUIRED)
 
+# Some packages below do not have cmake package config files.
+# Instead, we provide cmake find module files, like FindBBAPI.cmake.
+# This way users who build with cmake don't have to write their own.
+# The line below registers the current working directory with cmake
+# so that it can find the Find*.cmake module files.
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
 if (@HAVE_DATAWARP@)
   find_dependency(DataWarp REQUIRED)
 endif()


### PR DESCRIPTION
Install cmake find module files for dependencies like IBM BBAPI (``FindBBAPI.cmake``) and Cray Datawarp (``FindDataWarp.cmake``).

Update AXL cmake package config ``axlConfig.cmake`` to update the ``CMAKE_MODULE_PATH`` to include that install directory in its search.